### PR TITLE
feat: add iterm2 dark theme

### DIFF
--- a/flexoki_dark.itermcolors
+++ b/flexoki_dark.itermcolors
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Ansi 0 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.10980392156862745</real>
+        <key>Green Component</key>
+        <real>0.10588235294117647</real>
+        <key>Blue Component</key>
+        <real>0.10196078431372549</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 1 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.8196078431372549</real>
+        <key>Green Component</key>
+        <real>0.30196078431372547</real>
+        <key>Blue Component</key>
+        <real>0.2549019607843137</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 2 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.5294117647058824</real>
+        <key>Green Component</key>
+        <real>0.6039215686274509</real>
+        <key>Blue Component</key>
+        <real>0.2235294117647059</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 3 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.8156862745098039</real>
+        <key>Green Component</key>
+        <real>0.6352941176470588</real>
+        <key>Blue Component</key>
+        <real>0.08235294117647059</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 4 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.2627450980392157</real>
+        <key>Green Component</key>
+        <real>0.5215686274509804</real>
+        <key>Blue Component</key>
+        <real>0.7450980392156863</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 5 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.807843137254902</real>
+        <key>Green Component</key>
+        <real>0.36470588235294116</real>
+        <key>Blue Component</key>
+        <real>0.592156862745098</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 6 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.22745098039215686</real>
+        <key>Green Component</key>
+        <real>0.6627450980392157</real>
+        <key>Blue Component</key>
+        <real>0.6235294117647059</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 7 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.7176470588235294</real>
+        <key>Green Component</key>
+        <real>0.7098039215686275</real>
+        <key>Blue Component</key>
+        <real>0.6745098039215687</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 8 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.3411764705882353</real>
+        <key>Green Component</key>
+        <real>0.33725490196078434</real>
+        <key>Blue Component</key>
+        <real>0.3254901960784314</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 9 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.8196078431372549</real>
+        <key>Green Component</key>
+        <real>0.30196078431372547</real>
+        <key>Blue Component</key>
+        <real>0.2549019607843137</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 10 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.5294117647058824</real>
+        <key>Green Component</key>
+        <real>0.6039215686274509</real>
+        <key>Blue Component</key>
+        <real>0.2235294117647059</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 11 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.8156862745098039</real>
+        <key>Green Component</key>
+        <real>0.6352941176470588</real>
+        <key>Blue Component</key>
+        <real>0.08235294117647059</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 12 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.2627450980392157</real>
+        <key>Green Component</key>
+        <real>0.5215686274509804</real>
+        <key>Blue Component</key>
+        <real>0.7450980392156863</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 13 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.807843137254902</real>
+        <key>Green Component</key>
+        <real>0.36470588235294116</real>
+        <key>Blue Component</key>
+        <real>0.592156862745098</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 14 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.22745098039215686</real>
+        <key>Green Component</key>
+        <real>0.6627450980392157</real>
+        <key>Blue Component</key>
+        <real>0.6235294117647059</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Ansi 15 Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.807843137254902</real>
+        <key>Green Component</key>
+        <real>0.803921568627451</real>
+        <key>Blue Component</key>
+        <real>0.7647058823529411</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Background Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.10980392156862745</real>
+        <key>Green Component</key>
+        <real>0.10588235294117647</real>
+        <key>Blue Component</key>
+        <real>0.10196078431372549</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Foreground Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.807843137254902</real>
+        <key>Green Component</key>
+        <real>0.803921568627451</real>
+        <key>Blue Component</key>
+        <real>0.7647058823529411</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Link Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.2627450980392157</real>
+        <key>Green Component</key>
+        <real>0.5215686274509804</real>
+        <key>Blue Component</key>
+        <real>0.7450980392156863</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Bold Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>1</real>
+        <key>Green Component</key>
+        <real>0.9882352941176471</real>
+        <key>Blue Component</key>
+        <real>0.9411764705882353</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Cursor Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.807843137254902</real>
+        <key>Green Component</key>
+        <real>0.803921568627451</real>
+        <key>Blue Component</key>
+        <real>0.7647058823529411</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Cursor Text Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.10980392156862745</real>
+        <key>Green Component</key>
+        <real>0.10588235294117647</real>
+        <key>Blue Component</key>
+        <real>0.10196078431372549</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Selection Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.807843137254902</real>
+        <key>Green Component</key>
+        <real>0.803921568627451</real>
+        <key>Blue Component</key>
+        <real>0.7647058823529411</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+    <key>Selected Text Color</key>
+    <dict>
+        <key>Color Space</key>
+        <string>sRGB</string>
+        <key>Red Component</key>
+        <real>0.2627450980392157</real>
+        <key>Green Component</key>
+        <real>0.5215686274509804</real>
+        <key>Blue Component</key>
+        <real>0.7450980392156863</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Nice colors!
In next PR will provide light theme and generation script as well

<img width="682" alt="image" src="https://github.com/kepano/flexoki/assets/13676043/00ee79ec-6371-4eb8-8fdd-f9f0ddf40baa">
<img width="682" alt="image" src="https://github.com/kepano/flexoki/assets/13676043/42d08c76-d26e-4781-bb5f-81b30182cf0e">
