### PR TITLE
feat: Add GIMP palette

### DIFF
--- a/gimp/flexoki.gpl
+++ b/gimp/flexoki.gpl
@@ -1,0 +1,34 @@
+GIMP Palette
+Name: Flexoki
+Columns: 8
+# https://github.com/kepano/flexoki
+175  48  41 Dark red
+188  82  21 Dark orange
+173 131   1 Dark yellow
+102 128  11 Dark green
+ 36 131 123 Dark cyan
+ 32  94 166 Dark blue
+ 94  64 157 Dark purple
+160  47 111 Dark magenta
+209  77  65 Light red
+218 112  44 Light orange
+208 162  21 Light yellow
+135 154  57 Light green
+ 58 169 159 Light cyan
+ 67 133 190 Light blue
+139 126 200 Light purple
+206  93 151 Light magenta
+ 16  15  15 Black
+ 28  27  26 950
+ 40  39  38 900
+ 52  51  49 850
+ 64  62  60 800
+ 87  86  83 700
+111 110 105 600
+135 133 128 500
+183 181 172 300
+206 205 195 200
+218 216 206 150
+230 228 217 100
+242 240 229 50
+255 252 240 Paper


### PR DESCRIPTION
This pull request adds support for the GIMP palette format. Apart from GIMP other open-source graphics apps (Inkscape, Krita, etc.) also tend to support this palette format.

![20231009_115936](https://github.com/kepano/flexoki/assets/1627292/c028b6b7-ba98-4eba-bce3-19f712526836)
