### PR TITLE
Add link to iTerm2-Color-Schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Flexoki is available for the following apps and tools.
 - [Neovim](https://github.com/kepano/flexoki/tree/main/neovim) by @stevedylandev
 - [macOS Terminal](https://github.com/kepano/flexoki/tree/main/terminal) by @getninjaN
 - [Windows Terminal](https://github.com/kepano/flexoki/tree/main/windows-terminal) by @2joukevandermaas
+- Many more via [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes) by @jamesbvaughan
 
 ### Frameworks
 


### PR DESCRIPTION
This adds a new link to the readme pointing to [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes), a repository containing auto-generated colorschemes for a large number of applications (contrary to its more narrow name).

I've opened a PR on that repo adding Flexoki: https://github.com/mbadolato/iTerm2-Color-Schemes/pull/419 (This PR shouldn't be merged before that one.)

My addition to the readme here is small and the wording feels awkward, since it breaks the pattern established by the bullet points above it, and because the project's name implies that it's a duplicate of the existing iTerm2 support. I'm open to any suggestions for different ways to word it.