### PR TITLE
Set tx-2 color for punctuation, braces & brackets in VSCode

### DIFF
--- a/vscode/Flexoki-Dark-color-theme.json
+++ b/vscode/Flexoki-Dark-color-theme.json
@@ -80,7 +80,7 @@
     "terminal.ansiRed": "#AF3029",
     "terminal.ansiWhite": "#CECDC3",
     "terminal.ansiYellow": "#AD8301",
-    "terminal.background": "#343331",
+    "terminal.background": "#1C1B1A",
     "terminal.foreground": "#CECDC3",
     "gitDecoration.conflictingResourceForeground": "#DA702C",
     "gitDecoration.deletedResourceForeground": "#D14D41",
@@ -277,9 +277,12 @@
       }
     },
     {
-      "scope": "punctuation",
+      "scope": [
+        "punctuation",
+        "meta.brace"
+      ],
       "settings": {
-        "foreground": "#CECDC3"
+        "foreground": "#878580"
       }
     },
     {
@@ -292,7 +295,7 @@
     {
       "scope": "punctuation.definition.tag",
       "settings": {
-        "foreground": "#CECDC3",
+        "foreground": "#878580",
         "fontStyle": ""
       }
     },

--- a/vscode/Flexoki-Light-color-theme.json
+++ b/vscode/Flexoki-Light-color-theme.json
@@ -1,6 +1,6 @@
 {
   "name": "Flexoki Theme",
-  "type": "light",
+  "type": "dark",
   "colors": {
     "editor.background": "#FFFCF0",
     "editor.foreground": "#100F0F",
@@ -80,7 +80,7 @@
     "terminal.ansiRed": "#D14D41",
     "terminal.ansiWhite": "#100F0F",
     "terminal.ansiYellow": "#D0A215",
-    "terminal.background": "#DAD8CE",
+    "terminal.background": "#F2F0E5",
     "terminal.foreground": "#100F0F",
     "gitDecoration.conflictingResourceForeground": "#BC5215",
     "gitDecoration.deletedResourceForeground": "#AF3029",
@@ -277,9 +277,12 @@
       }
     },
     {
-      "scope": "punctuation",
+      "scope": [
+        "punctuation",
+        "meta.brace"
+      ],
       "settings": {
-        "foreground": "#100F0F"
+        "foreground": "#6F6E69"
       }
     },
     {
@@ -292,7 +295,7 @@
     {
       "scope": "punctuation.definition.tag",
       "settings": {
-        "foreground": "#100F0F",
+        "foreground": "#6F6E69",
         "fontStyle": ""
       }
     },


### PR DESCRIPTION
### Dark
<img width="960" alt="image" src="https://github.com/kepano/flexoki/assets/51397083/23890586-ba07-45ec-85a5-e0d2da3b16da">

### Light
<img width="960" alt="image" src="https://github.com/kepano/flexoki/assets/51397083/718c1914-d0d0-45ad-9432-a06eff7008d8">

Closes #31 