### PR TITLE
Fix iTerm2 light colour scheme bold and cursor guide colours

### DIFF
--- a/_generators/src/iterm2.ts
+++ b/_generators/src/iterm2.ts
@@ -118,7 +118,7 @@ const flexokiLightColorScheme: iTerm2ColorScheme = {
   'Background Color': palette.lt_bg,
   'Foreground Color': palette.lt_tx,
   'Link Color': palette.lt_tx_2,
-  'Bold Color': palette.paper,
+  'Bold Color': palette.lt_tx_2,
   'Cursor Color': palette.lt_tx,
   'Cursor Text Color': palette.lt_bg,
   'Cursor Guide Color': palette.paper,

--- a/_generators/src/iterm2.ts
+++ b/_generators/src/iterm2.ts
@@ -121,7 +121,7 @@ const flexokiLightColorScheme: iTerm2ColorScheme = {
   'Bold Color': palette.lt_tx_2,
   'Cursor Color': palette.lt_tx,
   'Cursor Text Color': palette.lt_bg,
-  'Cursor Guide Color': palette.paper,
+  'Cursor Guide Color': palette.lt_bg_2,
   'Selection Color': palette.lt_tx_2,
   'Selected Text Color': palette.lt_bg
 }
@@ -132,6 +132,7 @@ const flexokiLightDimmedColorScheme: iTerm2ColorScheme =
     {
       'Background Color': palette.lt_bg_2,
       'Cursor Text Color': palette.lt_bg_2,
+      'Cursor Guide Color': palette.lt_ui,
       'Selected Text Color': palette.lt_bg_2
     }
   )

--- a/iterm2/flexoki_light.itermcolors
+++ b/iterm2/flexoki_light.itermcolors
@@ -293,11 +293,11 @@
         <key>Color Space</key>
         <string>sRGB</string>
         <key>Red Component</key>
-        <real>1</real>
+        <real>0.9490196078431372</real>
         <key>Green Component</key>
-        <real>0.9882352941176471</real>
-        <key>Blue Component</key>
         <real>0.9411764705882353</real>
+        <key>Blue Component</key>
+        <real>0.8980392156862745</real>
         <key>Alpha Component</key>
         <real>1</real>
     </dict>

--- a/iterm2/flexoki_light.itermcolors
+++ b/iterm2/flexoki_light.itermcolors
@@ -254,11 +254,11 @@
         <key>Color Space</key>
         <string>sRGB</string>
         <key>Red Component</key>
-        <real>1</real>
+        <real>0.43529411764705883</real>
         <key>Green Component</key>
-        <real>0.9882352941176471</real>
+        <real>0.43137254901960786</real>
         <key>Blue Component</key>
-        <real>0.9411764705882353</real>
+        <real>0.4117647058823529</real>
         <key>Alpha Component</key>
         <real>1</real>
     </dict>

--- a/iterm2/flexoki_light_dimmed.itermcolors
+++ b/iterm2/flexoki_light_dimmed.itermcolors
@@ -293,11 +293,11 @@
         <key>Color Space</key>
         <string>sRGB</string>
         <key>Red Component</key>
-        <real>1</real>
+        <real>0.9490196078431372</real>
         <key>Green Component</key>
-        <real>0.9882352941176471</real>
-        <key>Blue Component</key>
         <real>0.9411764705882353</real>
+        <key>Blue Component</key>
+        <real>0.8980392156862745</real>
         <key>Alpha Component</key>
         <real>1</real>
     </dict>

--- a/iterm2/flexoki_light_dimmed.itermcolors
+++ b/iterm2/flexoki_light_dimmed.itermcolors
@@ -254,11 +254,11 @@
         <key>Color Space</key>
         <string>sRGB</string>
         <key>Red Component</key>
-        <real>1</real>
+        <real>0.43529411764705883</real>
         <key>Green Component</key>
-        <real>0.9882352941176471</real>
+        <real>0.43137254901960786</real>
         <key>Blue Component</key>
-        <real>0.9411764705882353</real>
+        <real>0.4117647058823529</real>
         <key>Alpha Component</key>
         <real>1</real>
     </dict>


### PR DESCRIPTION
The iTerm2 Bold and Cursor Guide colours are the same as the background, which means those elements are invisible when their preferences are enabled:

![image](https://github.com/kepano/flexoki/assets/1914/f50bfa07-4f2c-4d5d-bf98-0a8bdd6e2615)

Before:

![image](https://github.com/kepano/flexoki/assets/1914/e42ef714-ce96-43fe-aec6-9290922a5017)

After:

![image](https://github.com/kepano/flexoki/assets/1914/f5188e40-cfb3-4e68-bc89-b1ceee782af6)
