### PR TITLE
Add colorschemes for tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Flexoki is available for the following apps and tools.
 - [macOS Terminal](https://github.com/kepano/flexoki/tree/main/terminal) by @getninjaN
 - [Slack](https://github.com/kepano/flexoki/tree/main/slack) by @maxobat
 - [Sublime Text](https://github.com/kepano/flexoki-sublime) by @kepano
+- [tmux](https://github.com/kepano/flexoki/tree/main/tmux) by @tklai
 - [Visual Studio Code](https://github.com/kepano/flexoki/tree/main/vscode) by @Railly
 - [Warp](https://github.com/kepano/flexoki/tree/main/warp-terminal) by @tplesnar
 - [WezTerm](https://github.com/kepano/flexoki/tree/main/wezterm) by @jbromley

--- a/tmux/flexoki-dark.tmuxtheme
+++ b/tmux/flexoki-dark.tmuxtheme
@@ -1,0 +1,56 @@
+# Name: Flexoki
+# Variant: Dark
+# URL: https://stephango.com/flexoki
+# Description: An inky color scheme for prose and code.
+# Note: Color hexes in lower case to avoid tmux flag confusion
+
+flexoki_black="#100f0f"
+flexoki_base_950="#1c1b1a"
+flexoki_base_900="#282726"
+flexoki_base_850="#343331"
+flexoki_base_800="#403e3c"
+flexoki_base_700="#575653"
+flexoki_base_600="#6f6e69"
+flexoki_base_500="#878580"
+flexoki_base_300="#b7b5ac"
+flexoki_base_200="#cecdc3"
+flexoki_base_150="#dad8ce"
+flexoki_base_100="#e6e4d9"
+flexoki_base_50="#f2f0e5"
+flexoki_paper="#fffcf0"
+
+flexoki_red="#af3029"
+flexoki_orange="#bc5215"
+flexoki_yellow="#ad8301"
+flexoki_green="#66800b"
+flexoki_cyan="#24837b"
+flexoki_blue="#205ea6"
+flexoki_purple="#5e409d"
+flexoki_magenta="#a02f6f"
+
+flexoki_red_2="#d14d41"
+flexoki_orange_2="#da702c"
+flexoki_yellow_2="#d0a215"
+flexoki_green_2="#879a39"
+flexoki_cyan_2="#3aa99f"
+flexoki_blue_2="#4385be"
+flexoki_purple_2="#8b7ec8"
+flexoki_magenta_2="#ce5d97"
+
+color_tx_1=$flexoki_base_200
+color_tx_2=$flexoki_base_500
+color_tx_3=$flexoki_base_700
+color_bg_1=$flexoki_black
+color_bg_2=$flexoki_base_950
+color_ui_1=$flexoki_base_900
+color_ui_2=$flexoki_base_850
+color_ui_3=$flexoki_base_800
+
+color_red=$flexoki_red
+color_orange=$flexoki_orange
+color_yellow=$flexoki_yellow
+color_green=$flexoki_green
+color_cyan=$flexoki_cyan
+color_blue=$flexoki_blue
+color_purple=$flexoki_purple
+color_magenta=$flexoki_magenta

--- a/tmux/flexoki-light.tmuxtheme
+++ b/tmux/flexoki-light.tmuxtheme
@@ -1,0 +1,56 @@
+# Name: Flexoki
+# Variant: Light
+# URL: https://stephango.com/flexoki
+# Description: An inky color scheme for prose and code.
+# Note: Color hexes in lower case to avoid tmux flag confusion
+
+flexoki_black="#100f0f"
+flexoki_base_950="#1c1b1a"
+flexoki_base_900="#282726"
+flexoki_base_850="#343331"
+flexoki_base_800="#403e3c"
+flexoki_base_700="#575653"
+flexoki_base_600="#6f6e69"
+flexoki_base_500="#878580"
+flexoki_base_300="#b7b5ac"
+flexoki_base_200="#cecdc3"
+flexoki_base_150="#dad8ce"
+flexoki_base_100="#e6e4d9"
+flexoki_base_50="#f2f0e5"
+flexoki_paper="#fffcf0"
+
+flexoki_red="#d14d41"
+flexoki_orange="#da702c"
+flexoki_yellow="#d0a215"
+flexoki_green="#879a39"
+flexoki_cyan="#3aa99f"
+flexoki_blue="#4385be"
+flexoki_purple="#8b7ec8"
+flexoki_magenta="#ce5d97"
+
+flexoki_red_2="#af3029"
+flexoki_orange_2="#bc5215"
+flexoki_yellow_2="#ad8301"
+flexoki_green_2="#66800b"
+flexoki_cyan_2="#24837b"
+flexoki_blue_2="#205ea6"
+flexoki_purple_2="#5e409d"
+flexoki_magenta_2="#a02f6f"
+
+color_tx_1=$flexoki_black
+color_tx_2=$flexoki_base_600
+color_tx_3=$flexoki_base_300
+color_bg_1=$flexoki_paper
+color_bg_2=$flexoki_base_50
+color_ui_1=$flexoki_base_100
+color_ui_2=$flexoki_base_150
+color_ui_3=$flexoki_base_200
+
+color_red=$flexoki_red
+color_orange=$flexoki_orange
+color_yellow=$flexoki_yellow
+color_green=$flexoki_green
+color_cyan=$flexoki_cyan
+color_blue=$flexoki_blue
+color_purple=$flexoki_purple
+color_magenta=$flexoki_magenta


### PR DESCRIPTION
https://github.com/tmux/tmux/wiki#welcome-to-tmux

These files contain color variables for allowing end-users to configure the colors based on their layouts.

Hex colors are in lower case to avoid tmux flag confusion.

BTW ❤️

My setup:
![image](https://github.com/kepano/flexoki/assets/57529236/5b1b081f-9eec-466e-b5f0-2f8abbb0c4a5)
