### PR TITLE
update flexoki-vscode variants

### DIFF
--- a/vscode/Flexoki-Dark-color-theme.json
+++ b/vscode/Flexoki-Dark-color-theme.json
@@ -1,1142 +1,544 @@
 {
-  "name": "Flexoki Theme",
+  "name": "Flexoki",
   "type": "dark",
   "colors": {
     "editor.background": "#100F0F",
     "editor.foreground": "#CECDC3",
     "editor.hoverHighlightBackground": "#343331",
-    "editor.lineHighlightBackground": "#100F0F",
-    "editor.selectionBackground": "#403E3C",
-    "editor.wordHighlightBackground": "#343331",
-    "editor.wordHighlightStrongBackground": "#403E3C",
-    "editorBracketMatch.background": "#343331",
-    "editorBracketMatch.border": "#343331",
-    "editorCursor.foreground": "#CECDC3",
-    "editorGutter.addedBackground": "#66800B",
-    "editorGutter.background": "#100F0F",
-    "editorGutter.deletedBackground": "#AF3029",
-    "editorGutter.modifiedBackground": "#205EA6",
-    "editorIndentGuide.background": "#282726",
-    "editorInlayHint.background": "#100F0F",
-    "editorInlayHint.foreground": "#CECDC3",
-    "editorLineNumber.foreground": "#878580",
-    "editorLineNumber.background": "#100F0F",
-    "editorLink.activeForeground": "#205EA6",
-    "editorOverviewRuler.addedForeground": "#879A39",
-    "editorOverviewRuler.deletedForeground": "#D14D41",
-    "editorOverviewRuler.errorForeground": "#D14D41",
-    "editorOverviewRuler.findMatchForeground": "#4385BE",
-    "editorOverviewRuler.infoForeground": "#4385BE",
-    "editorOverviewRuler.modifiedForeground": "#4385BE",
-    "editorOverviewRuler.warningForeground": "#D0A215",
-    "editorRuler.foreground": "#282726",
-    "editorSuggestWidget.foreground": "#CECDC3",
-    "editorSuggestWidget.highlightForeground": "#CE5D97",
-    "editorSuggestWidget.selectedBackground": "#575653",
+    "editor.lineHighlightBackground": "#1C1B1A",
+    "editor.selectionBackground": "#CECDC333",
+    "editor.selectionHighlightBackground": "#CECDC333",
+    "editor.findMatchBackground": "#AD8301",
+    "editor.findMatchHighlightBackground": "#AD8301cc",
+    "editor.findRangeHighlightBackground": "#1C1B1A",
+    "editor.inactiveSelectionBackground": "#282726",
+    "editor.lineHighlightBorder": "#282726",
+    "editor.rangeHighlightBackground": "#403E3C",
+    "notifications.background": "#282726",
+    "editorInlayHint.typeBackground": "#343331",
+    "editorInlayHint.typeForeground": "#CECDC3",
     "editorWhitespace.foreground": "#403E3C",
-    "editorWidget.background": "#343331",
-    "editorWidget.border": "#343331",
-    "sideBar.background": "#1C1B1A",
-    "sideBar.foreground": "#CECDC3",
-    "sideBar.border": "#343331",
-    "sideBarSectionHeader.background": "#1C1B1A",
-    "sideBarSectionHeader.foreground": "#CECDC3",
-    "sideBarSectionHeader.border": "#343331",
-    "badge.background": "#4385BE",
-    "badge.foreground": "#100F0F",
-    "list.activeSelectionBackground": "#575653",
-    "list.activeSelectionForeground": "#CECDC3",
-    "list.focusBackground": "#282726",
-    "list.hoverBackground": "#343331",
-    "list.inactiveSelectionBackground": "#282726",
-    "titleBar.activeBackground": "#1C1B1A",
-    "titleBar.border": "#343331",
-    "activityBar.background": "#1C1B1A",
-    "activityBar.foreground": "#CECDC3",
-    "activityBar.border": "#343331",
-    "activityBarBadge.background": "#4385BE",
-    "activityBarBadge.foreground": "#100F0F",
-    "editorGroupHeader.tabsBackground": "#1C1B1A",
+    "editorIndentGuide.background1": "#343331",
+    "editorHoverWidget.background": "#282726",
+    "editorLineNumber.activeForeground": "#CECDC3",
+    "editorLineNumber.foreground": "#403E3C",
+    "editorGutter.background": "#100F0F",
+    "editorGutter.modifiedBackground": "#3AA99F",
+    "editorGutter.addedBackground": "#879A39",
+    "editorGutter.deletedBackground": "#D14D41",
+    "editorBracketMatch.background": "#282726",
+    "editorBracketMatch.border": "#343331",
+    "editorError.foreground": "#D14D41",
+    "editorWarning.foreground": "#DA702C",
+    "editorInfo.foreground": "#4385BE",
+    "diffEditor.insertedTextBackground": "#66800B99",
+    "diffEditor.removedTextBackground": "#AF302999",
+    "editorGroupHeader.tabsBackground": "#100F0F",
+    "editorGroup.border": "#343331",
+    "tab.activeBackground": "#100F0F",
     "tab.inactiveBackground": "#1C1B1A",
     "tab.inactiveForeground": "#878580",
+    "tab.activeForeground": "#CECDC3",
+    "tab.hoverBackground": "#343331",
+    "tab.unfocusedHoverBackground": "#343331",
+    "tab.border": "#343331",
     "tab.activeModifiedBorder": "#D0A215",
     "tab.inactiveModifiedBorder": "#4385BE",
     "tab.unfocusedActiveModifiedBorder": "#AD8301",
     "tab.unfocusedInactiveModifiedBorder": "#205EA6",
-    "tab.border": "#343331",
-    "terminal.ansiBlack": "#100F0F",
-    "terminal.ansiBlue": "#4385BE",
-    "terminal.ansiBrightBlack": "#343331",
-    "terminal.ansiBrightBlue": "#4385BE",
-    "terminal.ansiBrightCyan": "#3AA99F",
-    "terminal.ansiBrightGreen": "#879A39",
-    "terminal.ansiBrightMagenta": "#CE5D97",
-    "terminal.ansiBrightRed": "#D14D41",
-    "terminal.ansiBrightWhite": "#CECDC3",
-    "terminal.ansiBrightYellow": "#D0A215",
-    "terminal.ansiCyan": "#24837B",
-    "terminal.ansiGreen": "#66800B",
-    "terminal.ansiMagenta": "#A02F6F",
-    "terminal.ansiRed": "#AF3029",
-    "terminal.ansiWhite": "#CECDC3",
-    "terminal.ansiYellow": "#AD8301",
-    "terminal.background": "#1C1B1A",
-    "terminal.foreground": "#CECDC3",
-    "gitDecoration.conflictingResourceForeground": "#DA702C",
-    "gitDecoration.deletedResourceForeground": "#D14D41",
-    "gitDecoration.ignoredResourceForeground": "#575653",
-    "gitDecoration.modifiedResourceForeground": "#D0A215",
-    "gitDecoration.untrackedResourceForeground": "#3AA99F",
-    "statusBar.background": "#1C1B1A",
-    "statusBar.foreground": "#CECDC3",
-    "statusBar.border": "#343331",
-    "statusBar.noFolderBackground": "#343331",
-    "scrollbar.shadow": "#343331",
-    "scrollbarSlider.activeBackground": "#282726",
-    "scrollbarSlider.background": "#403E3C",
-    "scrollbarSlider.hoverBackground": "#575653",
-    "button.background": "#4385BE",
-    "button.foreground": "#100F0F",
-    "dropdown.background": "#282726",
-    "dropdown.border": "#403E3C",
-    "dropdown.foreground": "#CECDC3",
-    "extensionButton.prominentBackground": "#879A39",
-    "extensionButton.prominentForeground": "#CECDC3",
-    "extensionButton.prominentHoverBackground": "#879A39",
-    "focusBorder": "#4385BE",
-    "foreground": "#CECDC3",
-    "input.background": "#403E3C",
-    "input.border": "#343331",
-    "input.foreground": "#CECDC3",
-    "input.placeholderForeground": "#878580",
-    "inputOption.activeBorder": "#4385BE",
-    "panel.background": "#282726",
-    "panel.border": "#343331",
-    "panelTitle.activeBorder": "#4385BE",
-    "panelTitle.inactiveForeground": "#878580",
+    "editorWidget.background": "#1C1B1A",
+    "editorWidget.border": "#343331",
+    "editorSuggestWidget.background": "#100F0F",
+    "editorSuggestWidget.border": "#343331",
+    "editorSuggestWidget.foreground": "#CECDC3",
+    "editorSuggestWidget.highlightForeground": "#878580",
+    "editorSuggestWidget.selectedBackground": "#343331",
     "peekView.border": "#343331",
-    "peekViewEditor.background": "#282726",
-    "peekViewEditor.matchHighlightBackground": "#575653",
-    "peekViewEditorGutter.background": "#343331",
-    "peekViewResult.background": "#403E3C",
+    "peekViewEditor.background": "#100F0F",
+    "peekViewEditor.matchHighlightBackground": "#403E3C",
+    "peekViewResult.background": "#1C1B1A",
     "peekViewResult.fileForeground": "#CECDC3",
     "peekViewResult.lineForeground": "#878580",
-    "peekViewResult.matchHighlightBackground": "#343331",
-    "peekViewResult.selectionBackground": "#575653",
-    "peekViewResult.selectionForeground": "#CECDC3",
-    "peekViewTitle.background": "#575653",
-    "peekViewTitleDescription.foreground": "#575653",
+    "peekViewResult.matchHighlightBackground": "#403E3C",
+    "peekViewResult.selectionBackground": "#282726",
+    "peekViewResult.selectionForeground": "#575653",
+    "peekViewTitle.background": "#343331",
+    "peekViewTitleDescription.foreground": "#878580",
     "peekViewTitleLabel.foreground": "#CECDC3",
-    "progressBar.background": "#4385BE"
+    "merge.currentHeaderBackground": "#879A39",
+    "merge.currentContentBackground": "#66800B",
+    "merge.incomingHeaderBackground": "#3AA99F",
+    "merge.incomingContentBackground": "#24837B",
+    "merge.border": "#343331",
+    "merge.commonContentBackground": "#403E3C",
+    "merge.commonHeaderBackground": "#343331",
+    "panel.background": "#100F0F",
+    "panel.border": "#343331",
+    "panelTitle.activeBorder": "#403E3C",
+    "panelTitle.activeForeground": "#CECDC3",
+    "panelTitle.inactiveForeground": "#878580",
+    "statusBar.background": "#100F0F",
+    "statusBar.foreground": "#CECDC3",
+    "statusBar.border": "#343331",
+    "statusBar.debuggingBackground": "#D14D41",
+    "statusBar.debuggingForeground": "#CECDC3",
+    "statusBar.noFolderBackground": "#403E3C",
+    "statusBar.noFolderForeground": "#575653",
+    "titleBar.activeBackground": "#100F0F",
+    "titleBar.activeForeground": "#CECDC3",
+    "titleBar.inactiveBackground": "#1C1B1A",
+    "titleBar.inactiveForeground": "#878580",
+    "titleBar.border": "#343331",
+    "menu.foreground": "#CECDC3",
+    "menu.background": "#100F0F",
+    "menu.selectionForeground": "#CECDC3",
+    "menu.selectionBackground": "#343331",
+    "menu.border": "#343331",
+    "editorInlayHint.foreground": "#878580",
+    "editorInlayHint.background": "#343331",
+    "terminal.foreground": "#CECDC3",
+    "terminal.background": "#100F0F",
+    "terminalCursor.foreground": "#CECDC3",
+    "terminalCursor.background": "#100F0F",
+    "terminal.ansiRed": "#D14D41",
+    "terminal.ansiGreen": "#879A39",
+    "terminal.ansiYellow": "#D0A215",
+    "terminal.ansiBlue": "#4385BE",
+    "terminal.ansiMagenta": "#3AA99F",
+    "terminal.ansiCyan": "#3AA99F",
+    "activityBar.background": "#100F0F",
+    "activityBar.foreground": "#CECDC3",
+    "activityBar.inactiveForeground": "#878580",
+    "activityBar.activeBorder": "#CECDC3",
+    "activityBar.border": "#343331",
+    "sideBar.background": "#100F0F",
+    "sideBar.foreground": "#CECDC3",
+    "sideBar.border": "#343331",
+    "sideBarTitle.foreground": "#CECDC3",
+    "sideBarSectionHeader.background": "#1C1B1A",
+    "sideBarSectionHeader.foreground": "#CECDC3",
+    "sideBarSectionHeader.border": "#343331",
+    "sideBar.activeBackground": "#403E3C",
+    "sideBar.activeForeground": "#CECDC3",
+    "sideBar.hoverBackground": "#343331",
+    "sideBar.hoverForeground": "#878580",
+    "sideBar.folderIcon.foreground": "#879A39",
+    "sideBar.fileIcon.foreground": "#4385BE",
+    "list.warningForeground": "#DA702C",
+    "list.errorForeground": "#D14D41",
+    "list.inactiveSelectionBackground": "#343331",
+    "list.activeSelectionBackground": "#403E3C",
+    "list.inactiveSelectionForeground": "#CECDC3",
+    "list.activeSelectionForeground": "#CECDC3",
+    "list.hoverForeground": "#CECDC3",
+    "list.hoverBackground": "#343331",
+    "input.background": "#1C1B1A",
+    "input.foreground": "#CECDC3",
+    "input.border": "#343331",
+    "input.placeholderForeground": "#878580",
+    "inputOption.activeBorder": "#343331",
+    "inputOption.activeBackground": "#282726",
+    "inputOption.activeForeground": "#CECDC3",
+    "inputValidation.infoBackground": "#3AA99F",
+    "inputValidation.infoBorder": "#24837B",
+    "inputValidation.warningBackground": "#DA702C",
+    "inputValidation.warningBorder": "#BC5215",
+    "inputValidation.errorBackground": "#D14D41",
+    "inputValidation.errorBorder": "#AF3029",
+    "dropdown.background": "#1C1B1A",
+    "dropdown.foreground": "#CECDC3",
+    "dropdown.border": "#343331",
+    "dropdown.listBackground": "#100F0F",
+    "badge.background": "#3AA99F",
+    "activityBarBadge.background": "#3AA99F",
+    "button.background": "#3AA99F",
+    "button.foreground": "#100F0F",
+    "badge.foreground": "#100F0F",
+    "activityBarBadge.foreground": "#100F0F"
   },
   "tokenColors": [
     {
-      "scope": [
-        "comment"
-      ],
-      "settings": {
-        "foreground": "#878580"
-      }
-    },
-    {
-      "scope": [
-        "comment.block.documentation",
-        "comment.block.documentation variable.other"
-      ],
-      "settings": {
-        "foreground": "#878580",
-        "fontStyle": "italic"
-      }
-    },
-    {
-      "scope": [
-        "comment.block.documentation entity.name.type"
-      ],
+      "name": "plain",
+      "scope": ["source", "support.type.property-name.css"],
       "settings": {
         "foreground": "#CECDC3"
       }
     },
     {
-      "scope": [
-        "comment.block.documentation storage.type"
-      ],
+      "name": "classes",
+      "scope": ["entity.name.type.class"],
       "settings": {
-        "foreground": "#878580",
-        "fontStyle": "italic"
+        "foreground": "#DA702C"
       }
     },
     {
-      "scope": [
-        "string",
-        "punctuation.definition.string.template"
-      ],
-      "settings": {
-        "foreground": "#3AA99F"
-      }
-    },
-    {
-      "scope": "constant.numeric",
-      "settings": {
-        "foreground": "#8B7EC8"
-      }
-    },
-    {
-      "scope": "constant.language",
+      "name": "interfaces",
+      "scope": ["entity.name.type.interface", "entity.name.type"],
       "settings": {
         "foreground": "#D0A215"
       }
     },
     {
-      "scope": [
-        "constant.character",
-        "constant.other"
-      ],
+      "name": "structs",
+      "scope": ["entity.name.type.struct"],
       "settings": {
-        "foreground": "#3AA99F"
+        "foreground": "#DA702C"
       }
     },
     {
-      "scope": "variable.language.this",
+      "name": "enums",
+      "scope": ["entity.name.type.enum"],
       "settings": {
-        "foreground": "#CE5D97"
+        "foreground": "#DA702C"
       }
     },
     {
-      "scope": [
-        "keyword.control",
-        "keyword.operator.new"
-      ],
+      "name": "keys",
+      "scope": ["meta.object-literal.key", "support.type.property-name"],
+      "settings": {
+        "foreground": "#DA702C"
+      }
+    },
+    {
+      "name": "methods",
+      "scope": ["entity.name.function.method", "meta.function.method"],
       "settings": {
         "foreground": "#879A39"
       }
     },
     {
+      "name": "functions",
       "scope": [
-        "keyword.control.as"
-      ],
-      "settings": {
-        "foreground": "#CECDC3"
-      }
-    },
-    {
-      "scope": [
-        "keyword",
-        "keyword.operator.less",
-        "keyword.control.import",
-        "keyword.control.from"
-      ],
-      "settings": {
-        "foreground": "#D14D41"
-      }
-    },
-    {
-      "scope": [
-        "variable.other.object"
-      ],
-      "settings": {
-        "foreground": "#879A39"
-      }
-    },
-    {
-      "scope": [
-        "meta.tag.without-attributes.js.jsx"
-      ],
-      "settings": {
-        "foreground": "#CECDC3"
-      }
-    },
-    {
-      "scope": [
-        "variable.other.object.property"
-      ],
-      "settings": {
-        "foreground": "#CECDC3"
-      }
-    },
-    {
-      "scope": [
-        "variable.other.readwrite"
-      ],
-      "settings": {
-        "foreground": "#CECDC3"
-      }
-    },
-    {
-      "scope": [
-        "storage.modifier"
-      ],
-      "settings": {
-        "foreground": "#4385BE"
-      }
-    },
-    {
-      "scope": "keyword.operator",
-      "settings": {
-        "foreground": "#CECDC3",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "punctuation",
-        "meta.brace"
-      ],
-      "settings": {
-        "foreground": "#878580"
-      }
-    },
-    {
-      "scope": "punctuation.definition.comment",
-      "settings": {
-        "foreground": "#878580",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "punctuation.definition.tag",
-      "settings": {
-        "foreground": "#878580",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "string.quoted punctuation.definition.string",
-      "settings": {
-        "foreground": "#3AA99F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "string.regexp",
-        "string.regexp punctuation.definition.string"
-      ],
-      "settings": {
-        "foreground": "#3AA99F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "storage",
-      "settings": {
-        "foreground": "#CE5D97",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "storage.type",
-      "settings": {
-        "foreground": "#4385BE"
-      }
-    },
-    {
-      "scope": "storage.type.class",
-      "settings": {
-        "foreground": "#4385BE"
-      }
-    },
-    {
-      "scope": "entity.name.class",
-      "settings": {
-        "foreground": "#4385BE",
-        "fontStyle": "underline"
-      }
-    },
-    {
-      "scope": [
-        "meta.require",
-        "support.function.any-method",
-        "variable.function"
-      ],
-      "settings": {
-        "foreground": "#CECDC3"
-      }
-    },
-    {
-      "scope": [
-        "meta.definition.method",
-        "entity.name.function.js.jsx",
-        "entity.name.function.tsx"
-      ],
-      "settings": {
-        "foreground": "#DA702C"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.function"
-      ],
-      "settings": {
-        "foreground": "#DA702C"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.function.js",
-        "entity.name.function.ts"
-      ],
-      "settings": {
-        "foreground": "#DA702C"
-      }
-    },
-    {
-      "scope": [
-        "keyword.operator.assignment",
-        "keyword.operator.arithmetic",
-        "keyword.operator.bitwise",
-        "keyword.operator.relational",
-        "keyword.operator.increment",
-        "keyword.operator.decrement",
-        "keyword.operator.logical",
-        "keyword.operator.comparison",
-        "keyword.operator.ternary",
-        "keyword.operator.expression"
-      ],
-      "settings": {
-        "foreground": "#D14D41"
-      }
-    },
-    {
-      "scope": "variable.parameter",
-      "settings": {
-        "foreground": "#CECDC3",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "source.css.scss",
-        "source.css"
-      ],
-      "settings": {
-        "foreground": "#3AA99F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "entity.other.attribute-name"
-      ],
-      "settings": {
-        "foreground": "#D0A215",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "entity.other.inherited-class"
-      ],
-      "settings": {
-        "foreground": "#879A39",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
+        "entity.name.function",
         "support.function",
-        "support.variable.dom"
+        "meta.function-call.generic"
       ],
       "settings": {
-        "foreground": "#D0A215",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "support.constant",
-      "settings": {
-        "foreground": "#3AA99F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "support.type"
-      ],
-      "settings": {
-        "foreground": "#CECDC3",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "support.class"
-      ],
-      "settings": {
-        "foreground": "#CECDC3",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "invalid",
-      "settings": {
-        "foreground": "#D14D41",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "invalid.deprecated",
-      "settings": {
-        "foreground": "#D14D41",
-        "background": "#664E4D"
-      }
-    },
-    {
-      "scope": "invalid.illegal",
-      "settings": {
-        "foreground": "#878580"
-      }
-    },
-    {
-      "scope": [
-        "meta.diff",
-        "meta.diff.header"
-      ],
-      "settings": {
-        "foreground": "#878580"
-      }
-    },
-    {
-      "scope": "markup.deleted",
-      "settings": {
-        "foreground": "#D14D41"
-      }
-    },
-    {
-      "scope": "markup.inserted",
-      "settings": {
-        "foreground": "#879A39"
-      }
-    },
-    {
-      "scope": "markup.changed",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": "constant.numeric.line-number.find-in-files - match",
-      "settings": {
-        "foreground": "#879A39"
-      }
-    },
-    {
-      "scope": "entity.name.filename.find-in-files",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": "keyword.other",
-      "settings": {
-        "foreground": "#CECDC3"
-      }
-    },
-    {
-      "scope": [
-        "meta.property-value",
-        "support.constant.property-value",
-        "constant.other.color"
-      ],
-      "settings": {
-        "foreground": "#4385BE"
-      }
-    },
-    {
-      "scope": "meta.property-value punctuation.separator.key-value",
-      "settings": {
-        "foreground": "#878580"
-      }
-    },
-    {
-      "scope": [
-        "keyword.other.use",
-        "keyword.other.function.use",
-        "keyword.other.namespace",
-        "keyword.other.new",
-        "keyword.other.special-method",
-        "keyword.other.unit",
-        "keyword.other.use-as"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": [
-        "meta.use support.class.builtin",
-        "meta.other.inherited-class support.class.builtin"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": "meta.object-literal.key",
-      "settings": {
-        "foreground": "#DA702C"
-      }
-    },
-    {
-      "scope": "variable.parameter.function.coffee",
-      "settings": {
-        "foreground": "#4385BE",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "markup.deleted.git_gutter",
-      "settings": {
-        "foreground": "#D14D41"
-      }
-    },
-    {
-      "scope": "markup.inserted.git_gutter",
-      "settings": {}
-    },
-    {
-      "scope": "markup.changed.git_gutter",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": "meta.template.expression",
-      "settings": {
-        "foreground": "#4385BE"
-      }
-    },
-    {
-      "scope": [
-        "variable.other.constant.property",
-        "keyword.operator.ternary",
-        "keyword.operator.expression.typeof"
-      ],
-      "settings": {
-        "foreground": "#8B7EC8"
-      }
-    },
-    {
-      "scope": [
-        "keyword.operator.expression.keyof"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.type",
-        "support.type.python"
-      ],
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.type.class"
-      ],
-      "settings": {
-        "foreground": "#DA702C"
-      }
-    },
-    {
-      "scope": "token.info-token",
-      "settings": {
-        "foreground": "#4385BE"
-      }
-    },
-    {
-      "scope": "token.warn-token",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": "token.error-token",
-      "settings": {
-        "foreground": "#D14D41"
-      }
-    },
-    {
-      "scope": "token.debug-token",
-      "settings": {
-        "foreground": "#8B7EC8"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.tag.tsx",
-        "entity.name.tag.js.jsx",
-        "entity.name.tag.html",
-        "entity.name.tag.xml",
-        "entity.name.tag.script.html.vue",
-        "entity.name.tag.template.html.vue",
-        "entity.name.tag.style.html.vue",
-        "entity.name.tag.style.html.vue",
-        "entity.name.tag.script.html",
-        "entity.name.tag.template.html",
-        "entity.name.tag.style.html",
-        "entity.name.tag.block.any.html"
-      ],
-      "settings": {
-        "foreground": "#4385BE",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "support.class.component.tsx",
-        "support.class.component.js.jsx"
-      ],
-      "settings": {
-        "foreground": "#CE5D97",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "support.type.primitive.tsx",
-        "support.type.primitive.ts"
-      ],
-      "settings": {
-        "foreground": "#D14D41"
-      }
-    },
-    {
-      "scope": "storage.modifier.tsx",
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": "entity.other.inherited-class.tsx",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": "meta.object.member variable.other.readwrite.tsx",
-      "settings": {
-        "foreground": "#CECDC3"
-      }
-    },
-    {
-      "scope": "meta.structure.dictionary.json string.quoted.double.json",
-      "settings": {
-        "foreground": "#878580"
-      }
-    },
-    {
-      "scope": "meta.structure.dictionary.value.json string.quoted.double.json",
-      "settings": {
-        "foreground": "#3AA99F"
-      }
-    },
-    {
-      "scope": [
-        "meta.structure.dictionary.json",
-        "punctuation.definition.string"
-      ],
-      "settings": {
-        "foreground": "#3AA99F"
-      }
-    },
-    {
-      "scope": [
-        "meta.structure.dictionary.json",
-        "support.type.property-name.json"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.list.begin.markdown",
-        "punctuation.definition.list.begin.mdx",
-        "punctuation.definition.list.end.markdown",
-        "punctuation.definition.list.end.mdx",
-        "punctuation.definition.quote.begin.markdown",
-        "punctuation.definition.quote.begin.mdx",
-        "punctuation.definition.quote.end.markdown",
-        "punctuation.definition.quote.end.mdx",
-        "meta.separator.markdown",
-        "meta.separator.mdx",
-        "markup.inline.raw.string.markdown",
-        "markup.raw.code.text.mdx"
-      ],
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.section.markdown",
-        "entity.name.section.mdx"
-      ],
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.heading.markdown",
-        "punctuation.definition.heading.mdx"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": [
-        "markup.raw.inline.markdown",
-        "markup.raw.inline.mdx"
-      ],
-      "settings": {
-        "foreground": "#4385BE"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.bold.markdown",
-        "punctuation.definition.bold.mdx",
-        "punctuation.definition.italic.markdown",
-        "punctuation.definition.italic.mdx",
-        "punctuation.definition.entity"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.string.begin.markdown",
-        "punctuation.definition.string.begin.mdx",
-        "punctuation.definition.string.end.markdown",
-        "punctuation.definition.string.end.mdx"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.metadata.markdown",
-        "punctuation.definition.metadata.mdx"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": [
-        "markup.underline.link.markdown",
-        "markup.underline.link.image.markdown",
-        "string.other.link.destination.mdx",
-        "meta.image.inline.markdown",
-        "meta.image.inline.mdx"
-      ],
-      "settings": {
-        "foreground": "#CE5D97",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "markup.bold.markdown",
-        "string.other.strong.asterisk.mdx",
-        "markup.italic.markdown",
-        "markup.italic.mdx"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": [
-        "markup.italic.markdown",
-        "markup.italic.mdx"
-      ],
-      "settings": {
-        "fontStyle": "italic"
-      }
-    },
-    {
-      "scope": [
-        "markup.bold.markdown",
-        "markup.bold.mdx"
-      ],
-      "settings": {
+        "foreground": "#DA702C",
         "fontStyle": "bold"
       }
     },
     {
-      "scope": [
-        "markup.raw.block.markdown",
-        "markup.raw.block.mdx"
-      ],
-      "settings": {
-        "foreground": "#4385BE"
-      }
-    },
-    {
-      "scope": "keyword.other.rust",
-      "settings": {
-        "foreground": "#8B7EC8"
-      }
-    },
-    {
-      "scope": "keyword.other.fn.rust",
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "name": "PHP: Begin block",
-      "scope": [
-        "punctuation.section.embedded.begin.php",
-        "keyword.other.class.php"
-      ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "name": "PHP: Class name",
-      "scope": [
-        "support.class.php"
-      ],
+      "name": "variables",
+      "scope": ["variable", "meta.variable", "variable.other.object.property"],
       "settings": {
         "foreground": "#CECDC3"
       }
     },
     {
-      "name": "PHP: Function name",
-      "scope": [
-        "entity.name.function.php"
-      ],
-      "settings": {
-        "foreground": "#DA702C"
-      }
-    },
-    {
-      "name": "PHP: Meta use",
-      "scope": [
-        "meta.use.php"
-      ],
+      "name": "variablesOther",
+      "scope": ["variable.other.object", "variable.other.readwrite.alias"],
       "settings": {
         "foreground": "#879A39"
       }
     },
     {
-      "scope": "keyword.other.definition.ini",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "name": "Prisma: Primitive",
-      "scope": "support.type.primitive.prisma",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "name": "Prisma: Constant",
-      "scope": "support.constant.constant.prisma",
+      "name": "globalVariables",
+      "scope": ["variable.other.global", "variable.language.this"],
       "settings": {
         "foreground": "#CE5D97"
       }
     },
     {
-      "name": "Prisma: Relation",
-      "scope": "variable.language.relations.prisma",
+      "name": "localVariables",
+      "scope": ["variable.other.local"],
       "settings": {
-        "foreground": "#879A39"
+        "foreground": "#282726"
       }
     },
     {
-      "scope": "entity.name.tag.yaml",
+      "name": "parameters",
+      "scope": ["variable.parameter", "meta.parameter"],
       "settings": {
-        "foreground": "#CE5D97"
+        "foreground": "#CECDC3"
       }
     },
     {
-      "scope": [
-        "variable.other.object.property.java"
-      ],
-      "settings": {
-        "foreground": "#8B7EC8"
-      }
-    },
-    {
-      "scope": [
-        "storage.modifier.java"
-      ],
+      "name": "properties",
+      "scope": ["variable.other.property", "meta.property"],
       "settings": {
         "foreground": "#4385BE"
       }
     },
     {
-      "scope": "storage.type.java",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
+      "name": "strings",
       "scope": [
-        "keyword.other.package.java",
-        "keyword.other.import.java"
+        "string",
+        "string.other.link",
+        "markup.inline.raw.string.markdown"
       ],
-      "settings": {
-        "foreground": "#CE5D97"
-      }
-    },
-    {
-      "scope": "storage.modifier.package.java",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": "storage.modifier.import.java",
-      "settings": {
-        "foreground": "#CECDC3"
-      }
-    },
-    {
-      "scope": "punctuation.separator.java",
-      "settings": {
-        "foreground": "#CECDC3"
-      }
-    },
-    {
-      "scope": "meta.tag.xml",
       "settings": {
         "foreground": "#3AA99F"
       }
     },
     {
+      "name": "stringEscapeSequences",
+      "scope": ["constant.character.escape", "constant.other.placeholder"],
+      "settings": {
+        "foreground": "#CECDC3"
+      }
+    },
+    {
+      "name": "keywords",
+      "scope": ["keyword"],
+      "settings": {
+        "foreground": "#879A39"
+      }
+    },
+    {
+      "name": "keywordsControl",
       "scope": [
-        "keyword.other.declaration-specifier.swift",
-        "keyword.other.declaration-specifier.accessibility.swift"
+        "keyword.control.import",
+        "keyword.control.from",
+        "keyword.import"
       ],
       "settings": {
-        "foreground": "#CE5D97"
+        "foreground": "#D14D41"
       }
     },
     {
-      "scope": [
-        "support.type.swift",
-        "meta.function-result.swift",
-        "variable.language.swift",
-        "keyword.operator.custom.infix.swift"
-      ],
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": "variable.parameter.function.swift",
-      "settings": {
-        "foreground": "#878580"
-      }
-    },
-    {
-      "scope": "entity.name.function.swift",
-      "settings": {
-        "foreground": "#D0A215"
-      }
-    },
-    {
-      "scope": [
-        "variable.parameter.function.swift",
-        "meta.parameter-clause.swift"
-      ],
-      "settings": {
-        "foreground": "#878580"
-      }
-    },
-    {
-      "scope": [
-        "support.function.go"
-      ],
+      "name": "storageModifiers",
+      "scope": ["storage.modifier", "keyword.modifier", "storage.type"],
       "settings": {
         "foreground": "#4385BE"
       }
     },
     {
-      "scope": [
-        "keyword.operator.address.go",
-        "keyword.operator.pointer.go"
-      ],
+      "name": "comments",
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
-        "foreground": "#D0A215"
+        "foreground": "#878580"
       }
     },
     {
-      "scope": [
-        "keyword.channel.go"
-      ],
+      "name": "docComments",
+      "scope": ["comment.documentation", "comment.line.documentation"],
+      "settings": {
+        "foreground": "#575653"
+      }
+    },
+    {
+      "name": "numbers",
+      "scope": ["constant.numeric"],
       "settings": {
         "foreground": "#8B7EC8"
       }
     },
     {
-      "scope": [
-        "storage.type.numeric.go",
-        "storage.type.string.go",
-        "storage.type.error.go",
-        "storage.type.boolean.go",
-        "storage.type.byte.go",
-        "storage.type.uintptr.go",
-        "storage.type.error.go",
-        "storage.type.rune.go",
-        "storage.type.complex.go"
-      ],
+      "name": "booleans",
+      "scope": ["constant.language.boolean", "constant.language.json"],
       "settings": {
         "foreground": "#D0A215"
       }
     },
     {
-      "scope": [
-        "entity.name.tag.astro"
-      ],
+      "name": "operators",
+      "scope": ["keyword.operator"],
+      "settings": {
+        "foreground": "#D14D41"
+      }
+    },
+    {
+      "name": "macros",
+      "scope": ["entity.name.function.preprocessor", "meta.preprocessor"],
       "settings": {
         "foreground": "#4385BE"
       }
     },
     {
-      "scope": [
-        "support.class.component.astro"
-      ],
+      "name": "preprocessor",
+      "scope": ["meta.preprocessor"],
       "settings": {
-        "foreground": "#CE5D97",
-        "fontStyle": ""
+        "foreground": "#CE5D97"
       }
     },
     {
-      "scope": [
-        "support.function.builtin.python",
-        "meta.function-call.generic.python"
-      ],
+      "name": "urls",
+      "scope": ["markup.underline.link"],
       "settings": {
-        "foreground": "#DA702C"
+        "foreground": "#4385BE"
       }
     },
     {
+      "name": "tags",
+      "scope": ["entity.name.tag"],
+      "settings": {
+        "foreground": "#4385BE"
+      }
+    },
+    {
+      "name": "jsxTags",
+      "scope": ["support.class.component"],
+      "settings": {
+        "foreground": "#CE5D97"
+      }
+    },
+    {
+      "name": "attributes",
+      "scope": ["entity.other.attribute-name", "meta.attribute"],
+      "settings": {
+        "foreground": "#D0A215"
+      }
+    },
+    {
+      "name": "types",
+      "scope": ["support.type"],
+      "settings": {
+        "foreground": "#D0A215"
+      }
+    },
+    {
+      "name": "constants",
+      "scope": ["variable.other.constant", "variable.readonly"],
+      "settings": {
+        "foreground": "#CECDC3"
+      }
+    },
+    {
+      "name": "labels",
+      "scope": ["entity.name.label", "punctuation.definition.label"],
+      "settings": {
+        "foreground": "#CE5D97"
+      }
+    },
+    {
+      "name": "namespaces",
       "scope": [
-        "entity.name.function.decorator.python"
+        "entity.name.namespace",
+        "storage.modifier.namespace",
+        "markup.bold.markdown"
       ],
       "settings": {
         "foreground": "#D0A215"
       }
     },
     {
+      "name": "modules",
+      "scope": ["entity.name.module", "storage.modifier.module"],
+      "settings": {
+        "foreground": "#D14D41"
+      }
+    },
+    {
+      "name": "typeParameters",
+      "scope": ["variable.type.parameter", "variable.parameter.type"],
+      "settings": {
+        "foreground": "#DA702C"
+      }
+    },
+    {
+      "name": "exceptions",
+      "scope": ["keyword.control.exception", "keyword.control.trycatch"],
+      "settings": {
+        "foreground": "#CE5D97"
+      }
+    },
+    {
+      "name": "decorators",
       "scope": [
-        "entity.name.function.rust"
+        "meta.decorator",
+        "punctuation.decorator",
+        "entity.name.function.decorator"
       ],
+      "settings": {
+        "foreground": "#D0A215"
+      }
+    },
+    {
+      "name": "calls",
+      "scope": ["variable.function"],
+      "settings": {
+        "foreground": "#CECDC3"
+      }
+    },
+    {
+      "name": "punctuation",
+      "scope": [
+        "punctuation",
+        "punctuation.terminator",
+        "punctuation.definition.tag",
+        "punctuation.separator",
+        "punctuation.definition.string",
+        "punctuation.section.block"
+      ],
+      "settings": {
+        "foreground": "#878580"
+      }
+    },
+    {
+      "name": "yellow",
+      "scope": [
+        "storage.type.numeric.go",
+        "storage.type.byte.go",
+        "storage.type.boolean.go",
+        "storage.type.string.go",
+        "storage.type.uintptr.go",
+        "storage.type.error.go",
+        "storage.type.rune.go",
+        "constant.language.go",
+        "support.class.dart",
+        "keyword.other.documentation",
+        "storage.modifier.import.java",
+        "punctuation.definition.list.begin.markdown",
+        "punctuation.definition.quote.begin.markdown",
+        "meta.separator.markdown",
+        "entity.name.section.markdown"
+      ],
+      "settings": {
+        "foreground": "#D0A215"
+      }
+    },
+    {
+      "name": "green",
+      "scope": [],
+      "settings": {
+        "foreground": "#879A39"
+      }
+    },
+    {
+      "name": "cyan",
+      "scope": [
+        "markup.italic.markdown",
+        "support.type.python",
+        "variable.legacy.builtin.python",
+        "support.constant.property-value.css",
+        "storage.modifier.attribute.swift"
+      ],
+      "settings": {
+        "foreground": "#3AA99F"
+      }
+    },
+    {
+      "name": "blue",
+      "scope": [],
+      "settings": {
+        "foreground": "#4385BE"
+      }
+    },
+    {
+      "name": "purple",
+      "scope": ["keyword.channel.go", "keyword.other.platform.os.swift"],
+      "settings": {
+        "foreground": "#8B7EC8"
+      }
+    },
+    {
+      "name": "magenta",
+      "scope": ["punctuation.definition.heading.markdown"],
+      "settings": {
+        "foreground": "#CE5D97"
+      }
+    },
+    {
+      "name": "red",
+      "scope": [],
+      "settings": {
+        "foreground": "#D14D41"
+      }
+    },
+    {
+      "name": "orange",
+      "scope": [],
       "settings": {
         "foreground": "#DA702C"
       }

--- a/vscode/Flexoki-Light-color-theme.json
+++ b/vscode/Flexoki-Light-color-theme.json
@@ -1,1142 +1,544 @@
 {
-  "name": "Flexoki Theme",
-  "type": "dark",
+  "name": "Flexoki",
+  "type": "light",
   "colors": {
     "editor.background": "#FFFCF0",
     "editor.foreground": "#100F0F",
     "editor.hoverHighlightBackground": "#DAD8CE",
-    "editor.lineHighlightBackground": "#FFFCF0",
-    "editor.selectionBackground": "#CECDC3",
-    "editor.wordHighlightBackground": "#DAD8CE",
-    "editor.wordHighlightStrongBackground": "#CECDC3",
-    "editorBracketMatch.background": "#DAD8CE",
-    "editorBracketMatch.border": "#DAD8CE",
-    "editorCursor.foreground": "#100F0F",
-    "editorGutter.addedBackground": "#879A39",
-    "editorGutter.background": "#FFFCF0",
-    "editorGutter.deletedBackground": "#D14D41",
-    "editorGutter.modifiedBackground": "#4385BE",
-    "editorIndentGuide.background": "#E6E4D9",
-    "editorInlayHint.background": "#FFFCF0",
-    "editorInlayHint.foreground": "#100F0F",
-    "editorLineNumber.foreground": "#6F6E69",
-    "editorLineNumber.background": "#FFFCF0",
-    "editorLink.activeForeground": "#4385BE",
-    "editorOverviewRuler.addedForeground": "#66800B",
-    "editorOverviewRuler.deletedForeground": "#AF3029",
-    "editorOverviewRuler.errorForeground": "#AF3029",
-    "editorOverviewRuler.findMatchForeground": "#205EA6",
-    "editorOverviewRuler.infoForeground": "#205EA6",
-    "editorOverviewRuler.modifiedForeground": "#205EA6",
-    "editorOverviewRuler.warningForeground": "#AD8301",
-    "editorRuler.foreground": "#E6E4D9",
-    "editorSuggestWidget.foreground": "#100F0F",
-    "editorSuggestWidget.highlightForeground": "#A02F6F",
-    "editorSuggestWidget.selectedBackground": "#B7B5AC",
+    "editor.lineHighlightBackground": "#F2F0E5",
+    "editor.selectionBackground": "#100F0F44",
+    "editor.selectionHighlightBackground": "#100F0F44",
+    "editor.findMatchBackground": "#D0A215",
+    "editor.findMatchHighlightBackground": "#D0A215cc",
+    "editor.findRangeHighlightBackground": "#F2F0E5",
+    "editor.inactiveSelectionBackground": "#E6E4D9",
+    "editor.lineHighlightBorder": "#E6E4D9",
+    "editor.rangeHighlightBackground": "#CECDC3",
+    "notifications.background": "#E6E4D9",
+    "editorInlayHint.typeBackground": "#DAD8CE",
+    "editorInlayHint.typeForeground": "#100F0F",
     "editorWhitespace.foreground": "#CECDC3",
-    "editorWidget.background": "#DAD8CE",
-    "editorWidget.border": "#DAD8CE",
-    "sideBar.background": "#F2F0E5",
-    "sideBar.foreground": "#100F0F",
-    "sideBar.border": "#DAD8CE",
-    "sideBarSectionHeader.background": "#F2F0E5",
-    "sideBarSectionHeader.foreground": "#100F0F",
-    "sideBarSectionHeader.border": "#DAD8CE",
-    "badge.background": "#205EA6",
-    "badge.foreground": "#FFFCF0",
-    "list.activeSelectionBackground": "#B7B5AC",
-    "list.activeSelectionForeground": "#100F0F",
-    "list.focusBackground": "#E6E4D9",
-    "list.hoverBackground": "#DAD8CE",
-    "list.inactiveSelectionBackground": "#E6E4D9",
-    "titleBar.activeBackground": "#F2F0E5",
-    "titleBar.border": "#DAD8CE",
-    "activityBar.background": "#F2F0E5",
-    "activityBar.foreground": "#100F0F",
-    "activityBar.border": "#DAD8CE",
-    "activityBarBadge.background": "#205EA6",
-    "activityBarBadge.foreground": "#FFFCF0",
-    "editorGroupHeader.tabsBackground": "#F2F0E5",
+    "editorIndentGuide.background1": "#DAD8CE",
+    "editorHoverWidget.background": "#E6E4D9",
+    "editorLineNumber.activeForeground": "#100F0F",
+    "editorLineNumber.foreground": "#CECDC3",
+    "editorGutter.background": "#FFFCF0",
+    "editorGutter.modifiedBackground": "#24837B",
+    "editorGutter.addedBackground": "#66800B",
+    "editorGutter.deletedBackground": "#AF3029",
+    "editorBracketMatch.background": "#E6E4D9",
+    "editorBracketMatch.border": "#DAD8CE",
+    "editorError.foreground": "#AF3029",
+    "editorWarning.foreground": "#BC5215",
+    "editorInfo.foreground": "#205EA6",
+    "diffEditor.insertedTextBackground": "#879A3999",
+    "diffEditor.removedTextBackground": "#D14D4199",
+    "editorGroupHeader.tabsBackground": "#FFFCF0",
+    "editorGroup.border": "#DAD8CE",
+    "tab.activeBackground": "#FFFCF0",
     "tab.inactiveBackground": "#F2F0E5",
     "tab.inactiveForeground": "#6F6E69",
+    "tab.activeForeground": "#100F0F",
+    "tab.hoverBackground": "#DAD8CE",
+    "tab.unfocusedHoverBackground": "#DAD8CE",
+    "tab.border": "#DAD8CE",
     "tab.activeModifiedBorder": "#AD8301",
     "tab.inactiveModifiedBorder": "#205EA6",
     "tab.unfocusedActiveModifiedBorder": "#D0A215",
     "tab.unfocusedInactiveModifiedBorder": "#4385BE",
-    "tab.border": "#DAD8CE",
-    "terminal.ansiBlack": "#FFFCF0",
-    "terminal.ansiBlue": "#205EA6",
-    "terminal.ansiBrightBlack": "#DAD8CE",
-    "terminal.ansiBrightBlue": "#205EA6",
-    "terminal.ansiBrightCyan": "#24837B",
-    "terminal.ansiBrightGreen": "#66800B",
-    "terminal.ansiBrightMagenta": "#A02F6F",
-    "terminal.ansiBrightRed": "#AF3029",
-    "terminal.ansiBrightWhite": "#100F0F",
-    "terminal.ansiBrightYellow": "#AD8301",
-    "terminal.ansiCyan": "#3AA99F",
-    "terminal.ansiGreen": "#879A39",
-    "terminal.ansiMagenta": "#CE5D97",
-    "terminal.ansiRed": "#D14D41",
-    "terminal.ansiWhite": "#100F0F",
-    "terminal.ansiYellow": "#D0A215",
-    "terminal.background": "#F2F0E5",
-    "terminal.foreground": "#100F0F",
-    "gitDecoration.conflictingResourceForeground": "#BC5215",
-    "gitDecoration.deletedResourceForeground": "#AF3029",
-    "gitDecoration.ignoredResourceForeground": "#B7B5AC",
-    "gitDecoration.modifiedResourceForeground": "#AD8301",
-    "gitDecoration.untrackedResourceForeground": "#24837B",
-    "statusBar.background": "#F2F0E5",
-    "statusBar.foreground": "#100F0F",
-    "statusBar.border": "#DAD8CE",
-    "statusBar.noFolderBackground": "#DAD8CE",
-    "scrollbar.shadow": "#DAD8CE",
-    "scrollbarSlider.activeBackground": "#E6E4D9",
-    "scrollbarSlider.background": "#CECDC3",
-    "scrollbarSlider.hoverBackground": "#B7B5AC",
-    "button.background": "#205EA6",
-    "button.foreground": "#FFFCF0",
-    "dropdown.background": "#E6E4D9",
-    "dropdown.border": "#CECDC3",
-    "dropdown.foreground": "#100F0F",
-    "extensionButton.prominentBackground": "#66800B",
-    "extensionButton.prominentForeground": "#100F0F",
-    "extensionButton.prominentHoverBackground": "#66800B",
-    "focusBorder": "#205EA6",
-    "foreground": "#100F0F",
-    "input.background": "#CECDC3",
-    "input.border": "#DAD8CE",
-    "input.foreground": "#100F0F",
-    "input.placeholderForeground": "#6F6E69",
-    "inputOption.activeBorder": "#205EA6",
-    "panel.background": "#E6E4D9",
-    "panel.border": "#DAD8CE",
-    "panelTitle.activeBorder": "#205EA6",
-    "panelTitle.inactiveForeground": "#6F6E69",
+    "editorWidget.background": "#F2F0E5",
+    "editorWidget.border": "#DAD8CE",
+    "editorSuggestWidget.background": "#FFFCF0",
+    "editorSuggestWidget.border": "#DAD8CE",
+    "editorSuggestWidget.foreground": "#100F0F",
+    "editorSuggestWidget.highlightForeground": "#6F6E69",
+    "editorSuggestWidget.selectedBackground": "#DAD8CE",
     "peekView.border": "#DAD8CE",
-    "peekViewEditor.background": "#E6E4D9",
-    "peekViewEditor.matchHighlightBackground": "#B7B5AC",
-    "peekViewEditorGutter.background": "#DAD8CE",
-    "peekViewResult.background": "#CECDC3",
+    "peekViewEditor.background": "#FFFCF0",
+    "peekViewEditor.matchHighlightBackground": "#CECDC3",
+    "peekViewResult.background": "#F2F0E5",
     "peekViewResult.fileForeground": "#100F0F",
     "peekViewResult.lineForeground": "#6F6E69",
-    "peekViewResult.matchHighlightBackground": "#DAD8CE",
-    "peekViewResult.selectionBackground": "#B7B5AC",
-    "peekViewResult.selectionForeground": "#100F0F",
-    "peekViewTitle.background": "#B7B5AC",
-    "peekViewTitleDescription.foreground": "#B7B5AC",
+    "peekViewResult.matchHighlightBackground": "#CECDC3",
+    "peekViewResult.selectionBackground": "#E6E4D9",
+    "peekViewResult.selectionForeground": "#B7B5AC",
+    "peekViewTitle.background": "#DAD8CE",
+    "peekViewTitleDescription.foreground": "#6F6E69",
     "peekViewTitleLabel.foreground": "#100F0F",
-    "progressBar.background": "#205EA6"
+    "merge.currentHeaderBackground": "#66800B",
+    "merge.currentContentBackground": "#879A39",
+    "merge.incomingHeaderBackground": "#24837B",
+    "merge.incomingContentBackground": "#3AA99F",
+    "merge.border": "#DAD8CE",
+    "merge.commonContentBackground": "#CECDC3",
+    "merge.commonHeaderBackground": "#DAD8CE",
+    "panel.background": "#FFFCF0",
+    "panel.border": "#DAD8CE",
+    "panelTitle.activeBorder": "#CECDC3",
+    "panelTitle.activeForeground": "#100F0F",
+    "panelTitle.inactiveForeground": "#6F6E69",
+    "statusBar.background": "#FFFCF0",
+    "statusBar.foreground": "#100F0F",
+    "statusBar.border": "#DAD8CE",
+    "statusBar.debuggingBackground": "#AF3029",
+    "statusBar.debuggingForeground": "#100F0F",
+    "statusBar.noFolderBackground": "#CECDC3",
+    "statusBar.noFolderForeground": "#B7B5AC",
+    "titleBar.activeBackground": "#FFFCF0",
+    "titleBar.activeForeground": "#100F0F",
+    "titleBar.inactiveBackground": "#F2F0E5",
+    "titleBar.inactiveForeground": "#6F6E69",
+    "titleBar.border": "#DAD8CE",
+    "menu.foreground": "#100F0F",
+    "menu.background": "#FFFCF0",
+    "menu.selectionForeground": "#100F0F",
+    "menu.selectionBackground": "#DAD8CE",
+    "menu.border": "#DAD8CE",
+    "editorInlayHint.foreground": "#6F6E69",
+    "editorInlayHint.background": "#DAD8CE",
+    "terminal.foreground": "#100F0F",
+    "terminal.background": "#FFFCF0",
+    "terminalCursor.foreground": "#100F0F",
+    "terminalCursor.background": "#FFFCF0",
+    "terminal.ansiRed": "#AF3029",
+    "terminal.ansiGreen": "#66800B",
+    "terminal.ansiYellow": "#AD8301",
+    "terminal.ansiBlue": "#205EA6",
+    "terminal.ansiMagenta": "#24837B",
+    "terminal.ansiCyan": "#24837B",
+    "activityBar.background": "#FFFCF0",
+    "activityBar.foreground": "#100F0F",
+    "activityBar.inactiveForeground": "#6F6E69",
+    "activityBar.activeBorder": "#100F0F",
+    "activityBar.border": "#DAD8CE",
+    "sideBar.background": "#FFFCF0",
+    "sideBar.foreground": "#100F0F",
+    "sideBar.border": "#DAD8CE",
+    "sideBarTitle.foreground": "#100F0F",
+    "sideBarSectionHeader.background": "#F2F0E5",
+    "sideBarSectionHeader.foreground": "#100F0F",
+    "sideBarSectionHeader.border": "#DAD8CE",
+    "sideBar.activeBackground": "#CECDC3",
+    "sideBar.activeForeground": "#100F0F",
+    "sideBar.hoverBackground": "#DAD8CE",
+    "sideBar.hoverForeground": "#6F6E69",
+    "sideBar.folderIcon.foreground": "#66800B",
+    "sideBar.fileIcon.foreground": "#205EA6",
+    "list.warningForeground": "#BC5215",
+    "list.errorForeground": "#AF3029",
+    "list.inactiveSelectionBackground": "#DAD8CE",
+    "list.activeSelectionBackground": "#CECDC3",
+    "list.inactiveSelectionForeground": "#100F0F",
+    "list.activeSelectionForeground": "#100F0F",
+    "list.hoverForeground": "#100F0F",
+    "list.hoverBackground": "#DAD8CE",
+    "input.background": "#F2F0E5",
+    "input.foreground": "#100F0F",
+    "input.border": "#DAD8CE",
+    "input.placeholderForeground": "#6F6E69",
+    "inputOption.activeBorder": "#DAD8CE",
+    "inputOption.activeBackground": "#E6E4D9",
+    "inputOption.activeForeground": "#100F0F",
+    "inputValidation.infoBackground": "#24837B",
+    "inputValidation.infoBorder": "#3AA99F",
+    "inputValidation.warningBackground": "#BC5215",
+    "inputValidation.warningBorder": "#DA702C",
+    "inputValidation.errorBackground": "#AF3029",
+    "inputValidation.errorBorder": "#D14D41",
+    "dropdown.background": "#F2F0E5",
+    "dropdown.foreground": "#100F0F",
+    "dropdown.border": "#DAD8CE",
+    "dropdown.listBackground": "#FFFCF0",
+    "badge.background": "#24837B",
+    "activityBarBadge.background": "#24837B",
+    "button.background": "#24837B",
+    "button.foreground": "#FFFCF0",
+    "badge.foreground": "#FFFCF0",
+    "activityBarBadge.foreground": "#FFFCF0"
   },
   "tokenColors": [
     {
-      "scope": [
-        "comment"
-      ],
-      "settings": {
-        "foreground": "#6F6E69"
-      }
-    },
-    {
-      "scope": [
-        "comment.block.documentation",
-        "comment.block.documentation variable.other"
-      ],
-      "settings": {
-        "foreground": "#6F6E69",
-        "fontStyle": "italic"
-      }
-    },
-    {
-      "scope": [
-        "comment.block.documentation entity.name.type"
-      ],
+      "name": "plain",
+      "scope": ["source", "support.type.property-name.css"],
       "settings": {
         "foreground": "#100F0F"
       }
     },
     {
-      "scope": [
-        "comment.block.documentation storage.type"
-      ],
+      "name": "classes",
+      "scope": ["entity.name.type.class"],
       "settings": {
-        "foreground": "#6F6E69",
-        "fontStyle": "italic"
+        "foreground": "#BC5215"
       }
     },
     {
-      "scope": [
-        "string",
-        "punctuation.definition.string.template"
-      ],
-      "settings": {
-        "foreground": "#24837B"
-      }
-    },
-    {
-      "scope": "constant.numeric",
-      "settings": {
-        "foreground": "#5E409D"
-      }
-    },
-    {
-      "scope": "constant.language",
+      "name": "interfaces",
+      "scope": ["entity.name.type.interface", "entity.name.type"],
       "settings": {
         "foreground": "#AD8301"
       }
     },
     {
-      "scope": [
-        "constant.character",
-        "constant.other"
-      ],
+      "name": "structs",
+      "scope": ["entity.name.type.struct"],
       "settings": {
-        "foreground": "#24837B"
+        "foreground": "#BC5215"
       }
     },
     {
-      "scope": "variable.language.this",
+      "name": "enums",
+      "scope": ["entity.name.type.enum"],
       "settings": {
-        "foreground": "#A02F6F"
+        "foreground": "#BC5215"
       }
     },
     {
-      "scope": [
-        "keyword.control",
-        "keyword.operator.new"
-      ],
+      "name": "keys",
+      "scope": ["meta.object-literal.key", "support.type.property-name"],
+      "settings": {
+        "foreground": "#BC5215"
+      }
+    },
+    {
+      "name": "methods",
+      "scope": ["entity.name.function.method", "meta.function.method"],
       "settings": {
         "foreground": "#66800B"
       }
     },
     {
+      "name": "functions",
       "scope": [
-        "keyword.control.as"
-      ],
-      "settings": {
-        "foreground": "#100F0F"
-      }
-    },
-    {
-      "scope": [
-        "keyword",
-        "keyword.operator.less",
-        "keyword.control.import",
-        "keyword.control.from"
-      ],
-      "settings": {
-        "foreground": "#AF3029"
-      }
-    },
-    {
-      "scope": [
-        "variable.other.object"
-      ],
-      "settings": {
-        "foreground": "#66800B"
-      }
-    },
-    {
-      "scope": [
-        "meta.tag.without-attributes.js.jsx"
-      ],
-      "settings": {
-        "foreground": "#100F0F"
-      }
-    },
-    {
-      "scope": [
-        "variable.other.object.property"
-      ],
-      "settings": {
-        "foreground": "#100F0F"
-      }
-    },
-    {
-      "scope": [
-        "variable.other.readwrite"
-      ],
-      "settings": {
-        "foreground": "#100F0F"
-      }
-    },
-    {
-      "scope": [
-        "storage.modifier"
-      ],
-      "settings": {
-        "foreground": "#205EA6"
-      }
-    },
-    {
-      "scope": "keyword.operator",
-      "settings": {
-        "foreground": "#100F0F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "punctuation",
-        "meta.brace"
-      ],
-      "settings": {
-        "foreground": "#6F6E69"
-      }
-    },
-    {
-      "scope": "punctuation.definition.comment",
-      "settings": {
-        "foreground": "#6F6E69",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "punctuation.definition.tag",
-      "settings": {
-        "foreground": "#6F6E69",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "string.quoted punctuation.definition.string",
-      "settings": {
-        "foreground": "#24837B",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "string.regexp",
-        "string.regexp punctuation.definition.string"
-      ],
-      "settings": {
-        "foreground": "#24837B",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "storage",
-      "settings": {
-        "foreground": "#A02F6F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "storage.type",
-      "settings": {
-        "foreground": "#205EA6"
-      }
-    },
-    {
-      "scope": "storage.type.class",
-      "settings": {
-        "foreground": "#205EA6"
-      }
-    },
-    {
-      "scope": "entity.name.class",
-      "settings": {
-        "foreground": "#205EA6",
-        "fontStyle": "underline"
-      }
-    },
-    {
-      "scope": [
-        "meta.require",
-        "support.function.any-method",
-        "variable.function"
-      ],
-      "settings": {
-        "foreground": "#100F0F"
-      }
-    },
-    {
-      "scope": [
-        "meta.definition.method",
-        "entity.name.function.js.jsx",
-        "entity.name.function.tsx"
-      ],
-      "settings": {
-        "foreground": "#BC5215"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.function"
-      ],
-      "settings": {
-        "foreground": "#BC5215"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.function.js",
-        "entity.name.function.ts"
-      ],
-      "settings": {
-        "foreground": "#BC5215"
-      }
-    },
-    {
-      "scope": [
-        "keyword.operator.assignment",
-        "keyword.operator.arithmetic",
-        "keyword.operator.bitwise",
-        "keyword.operator.relational",
-        "keyword.operator.increment",
-        "keyword.operator.decrement",
-        "keyword.operator.logical",
-        "keyword.operator.comparison",
-        "keyword.operator.ternary",
-        "keyword.operator.expression"
-      ],
-      "settings": {
-        "foreground": "#AF3029"
-      }
-    },
-    {
-      "scope": "variable.parameter",
-      "settings": {
-        "foreground": "#100F0F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "source.css.scss",
-        "source.css"
-      ],
-      "settings": {
-        "foreground": "#24837B",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "entity.other.attribute-name"
-      ],
-      "settings": {
-        "foreground": "#AD8301",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "entity.other.inherited-class"
-      ],
-      "settings": {
-        "foreground": "#66800B",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
+        "entity.name.function",
         "support.function",
-        "support.variable.dom"
+        "meta.function-call.generic"
       ],
       "settings": {
-        "foreground": "#AD8301",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "support.constant",
-      "settings": {
-        "foreground": "#24837B",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "support.type"
-      ],
-      "settings": {
-        "foreground": "#100F0F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "support.class"
-      ],
-      "settings": {
-        "foreground": "#100F0F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "invalid",
-      "settings": {
-        "foreground": "#AF3029",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "invalid.deprecated",
-      "settings": {
-        "foreground": "#AF3029",
-        "background": "#664E4D"
-      }
-    },
-    {
-      "scope": "invalid.illegal",
-      "settings": {
-        "foreground": "#6F6E69"
-      }
-    },
-    {
-      "scope": [
-        "meta.diff",
-        "meta.diff.header"
-      ],
-      "settings": {
-        "foreground": "#6F6E69"
-      }
-    },
-    {
-      "scope": "markup.deleted",
-      "settings": {
-        "foreground": "#AF3029"
-      }
-    },
-    {
-      "scope": "markup.inserted",
-      "settings": {
-        "foreground": "#66800B"
-      }
-    },
-    {
-      "scope": "markup.changed",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": "constant.numeric.line-number.find-in-files - match",
-      "settings": {
-        "foreground": "#66800B"
-      }
-    },
-    {
-      "scope": "entity.name.filename.find-in-files",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": "keyword.other",
-      "settings": {
-        "foreground": "#100F0F"
-      }
-    },
-    {
-      "scope": [
-        "meta.property-value",
-        "support.constant.property-value",
-        "constant.other.color"
-      ],
-      "settings": {
-        "foreground": "#205EA6"
-      }
-    },
-    {
-      "scope": "meta.property-value punctuation.separator.key-value",
-      "settings": {
-        "foreground": "#6F6E69"
-      }
-    },
-    {
-      "scope": [
-        "keyword.other.use",
-        "keyword.other.function.use",
-        "keyword.other.namespace",
-        "keyword.other.new",
-        "keyword.other.special-method",
-        "keyword.other.unit",
-        "keyword.other.use-as"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": [
-        "meta.use support.class.builtin",
-        "meta.other.inherited-class support.class.builtin"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": "meta.object-literal.key",
-      "settings": {
-        "foreground": "#BC5215"
-      }
-    },
-    {
-      "scope": "variable.parameter.function.coffee",
-      "settings": {
-        "foreground": "#205EA6",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": "markup.deleted.git_gutter",
-      "settings": {
-        "foreground": "#AF3029"
-      }
-    },
-    {
-      "scope": "markup.inserted.git_gutter",
-      "settings": {}
-    },
-    {
-      "scope": "markup.changed.git_gutter",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": "meta.template.expression",
-      "settings": {
-        "foreground": "#205EA6"
-      }
-    },
-    {
-      "scope": [
-        "variable.other.constant.property",
-        "keyword.operator.ternary",
-        "keyword.operator.expression.typeof"
-      ],
-      "settings": {
-        "foreground": "#5E409D"
-      }
-    },
-    {
-      "scope": [
-        "keyword.operator.expression.keyof"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.type",
-        "support.type.python"
-      ],
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.type.class"
-      ],
-      "settings": {
-        "foreground": "#BC5215"
-      }
-    },
-    {
-      "scope": "token.info-token",
-      "settings": {
-        "foreground": "#205EA6"
-      }
-    },
-    {
-      "scope": "token.warn-token",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": "token.error-token",
-      "settings": {
-        "foreground": "#AF3029"
-      }
-    },
-    {
-      "scope": "token.debug-token",
-      "settings": {
-        "foreground": "#5E409D"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.tag.tsx",
-        "entity.name.tag.js.jsx",
-        "entity.name.tag.html",
-        "entity.name.tag.xml",
-        "entity.name.tag.script.html.vue",
-        "entity.name.tag.template.html.vue",
-        "entity.name.tag.style.html.vue",
-        "entity.name.tag.style.html.vue",
-        "entity.name.tag.script.html",
-        "entity.name.tag.template.html",
-        "entity.name.tag.style.html",
-        "entity.name.tag.block.any.html"
-      ],
-      "settings": {
-        "foreground": "#205EA6",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "support.class.component.tsx",
-        "support.class.component.js.jsx"
-      ],
-      "settings": {
-        "foreground": "#A02F6F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "support.type.primitive.tsx",
-        "support.type.primitive.ts"
-      ],
-      "settings": {
-        "foreground": "#AF3029"
-      }
-    },
-    {
-      "scope": "storage.modifier.tsx",
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": "entity.other.inherited-class.tsx",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": "meta.object.member variable.other.readwrite.tsx",
-      "settings": {
-        "foreground": "#100F0F"
-      }
-    },
-    {
-      "scope": "meta.structure.dictionary.json string.quoted.double.json",
-      "settings": {
-        "foreground": "#6F6E69"
-      }
-    },
-    {
-      "scope": "meta.structure.dictionary.value.json string.quoted.double.json",
-      "settings": {
-        "foreground": "#24837B"
-      }
-    },
-    {
-      "scope": [
-        "meta.structure.dictionary.json",
-        "punctuation.definition.string"
-      ],
-      "settings": {
-        "foreground": "#24837B"
-      }
-    },
-    {
-      "scope": [
-        "meta.structure.dictionary.json",
-        "support.type.property-name.json"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.list.begin.markdown",
-        "punctuation.definition.list.begin.mdx",
-        "punctuation.definition.list.end.markdown",
-        "punctuation.definition.list.end.mdx",
-        "punctuation.definition.quote.begin.markdown",
-        "punctuation.definition.quote.begin.mdx",
-        "punctuation.definition.quote.end.markdown",
-        "punctuation.definition.quote.end.mdx",
-        "meta.separator.markdown",
-        "meta.separator.mdx",
-        "markup.inline.raw.string.markdown",
-        "markup.raw.code.text.mdx"
-      ],
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": [
-        "entity.name.section.markdown",
-        "entity.name.section.mdx"
-      ],
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.heading.markdown",
-        "punctuation.definition.heading.mdx"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": [
-        "markup.raw.inline.markdown",
-        "markup.raw.inline.mdx"
-      ],
-      "settings": {
-        "foreground": "#205EA6"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.bold.markdown",
-        "punctuation.definition.bold.mdx",
-        "punctuation.definition.italic.markdown",
-        "punctuation.definition.italic.mdx",
-        "punctuation.definition.entity"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.string.begin.markdown",
-        "punctuation.definition.string.begin.mdx",
-        "punctuation.definition.string.end.markdown",
-        "punctuation.definition.string.end.mdx"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": [
-        "punctuation.definition.metadata.markdown",
-        "punctuation.definition.metadata.mdx"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": [
-        "markup.underline.link.markdown",
-        "markup.underline.link.image.markdown",
-        "string.other.link.destination.mdx",
-        "meta.image.inline.markdown",
-        "meta.image.inline.mdx"
-      ],
-      "settings": {
-        "foreground": "#A02F6F",
-        "fontStyle": ""
-      }
-    },
-    {
-      "scope": [
-        "markup.bold.markdown",
-        "string.other.strong.asterisk.mdx",
-        "markup.italic.markdown",
-        "markup.italic.mdx"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": [
-        "markup.italic.markdown",
-        "markup.italic.mdx"
-      ],
-      "settings": {
-        "fontStyle": "italic"
-      }
-    },
-    {
-      "scope": [
-        "markup.bold.markdown",
-        "markup.bold.mdx"
-      ],
-      "settings": {
+        "foreground": "#BC5215",
         "fontStyle": "bold"
       }
     },
     {
-      "scope": [
-        "markup.raw.block.markdown",
-        "markup.raw.block.mdx"
-      ],
-      "settings": {
-        "foreground": "#205EA6"
-      }
-    },
-    {
-      "scope": "keyword.other.rust",
-      "settings": {
-        "foreground": "#5E409D"
-      }
-    },
-    {
-      "scope": "keyword.other.fn.rust",
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "name": "PHP: Begin block",
-      "scope": [
-        "punctuation.section.embedded.begin.php",
-        "keyword.other.class.php"
-      ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "name": "PHP: Class name",
-      "scope": [
-        "support.class.php"
-      ],
+      "name": "variables",
+      "scope": ["variable", "meta.variable", "variable.other.object.property"],
       "settings": {
         "foreground": "#100F0F"
       }
     },
     {
-      "name": "PHP: Function name",
-      "scope": [
-        "entity.name.function.php"
-      ],
-      "settings": {
-        "foreground": "#BC5215"
-      }
-    },
-    {
-      "name": "PHP: Meta use",
-      "scope": [
-        "meta.use.php"
-      ],
+      "name": "variablesOther",
+      "scope": ["variable.other.object", "variable.other.readwrite.alias"],
       "settings": {
         "foreground": "#66800B"
       }
     },
     {
-      "scope": "keyword.other.definition.ini",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "name": "Prisma: Primitive",
-      "scope": "support.type.primitive.prisma",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "name": "Prisma: Constant",
-      "scope": "support.constant.constant.prisma",
+      "name": "globalVariables",
+      "scope": ["variable.other.global", "variable.language.this"],
       "settings": {
         "foreground": "#A02F6F"
       }
     },
     {
-      "name": "Prisma: Relation",
-      "scope": "variable.language.relations.prisma",
+      "name": "localVariables",
+      "scope": ["variable.other.local"],
       "settings": {
-        "foreground": "#66800B"
+        "foreground": "#E6E4D9"
       }
     },
     {
-      "scope": "entity.name.tag.yaml",
+      "name": "parameters",
+      "scope": ["variable.parameter", "meta.parameter"],
       "settings": {
-        "foreground": "#A02F6F"
+        "foreground": "#100F0F"
       }
     },
     {
-      "scope": [
-        "variable.other.object.property.java"
-      ],
-      "settings": {
-        "foreground": "#5E409D"
-      }
-    },
-    {
-      "scope": [
-        "storage.modifier.java"
-      ],
+      "name": "properties",
+      "scope": ["variable.other.property", "meta.property"],
       "settings": {
         "foreground": "#205EA6"
       }
     },
     {
-      "scope": "storage.type.java",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
+      "name": "strings",
       "scope": [
-        "keyword.other.package.java",
-        "keyword.other.import.java"
+        "string",
+        "string.other.link",
+        "markup.inline.raw.string.markdown"
       ],
-      "settings": {
-        "foreground": "#A02F6F"
-      }
-    },
-    {
-      "scope": "storage.modifier.package.java",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": "storage.modifier.import.java",
-      "settings": {
-        "foreground": "#100F0F"
-      }
-    },
-    {
-      "scope": "punctuation.separator.java",
-      "settings": {
-        "foreground": "#100F0F"
-      }
-    },
-    {
-      "scope": "meta.tag.xml",
       "settings": {
         "foreground": "#24837B"
       }
     },
     {
+      "name": "stringEscapeSequences",
+      "scope": ["constant.character.escape", "constant.other.placeholder"],
+      "settings": {
+        "foreground": "#100F0F"
+      }
+    },
+    {
+      "name": "keywords",
+      "scope": ["keyword"],
+      "settings": {
+        "foreground": "#66800B"
+      }
+    },
+    {
+      "name": "keywordsControl",
       "scope": [
-        "keyword.other.declaration-specifier.swift",
-        "keyword.other.declaration-specifier.accessibility.swift"
+        "keyword.control.import",
+        "keyword.control.from",
+        "keyword.import"
       ],
       "settings": {
-        "foreground": "#A02F6F"
+        "foreground": "#AF3029"
       }
     },
     {
-      "scope": [
-        "support.type.swift",
-        "meta.function-result.swift",
-        "variable.language.swift",
-        "keyword.operator.custom.infix.swift"
-      ],
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": "variable.parameter.function.swift",
-      "settings": {
-        "foreground": "#6F6E69"
-      }
-    },
-    {
-      "scope": "entity.name.function.swift",
-      "settings": {
-        "foreground": "#AD8301"
-      }
-    },
-    {
-      "scope": [
-        "variable.parameter.function.swift",
-        "meta.parameter-clause.swift"
-      ],
-      "settings": {
-        "foreground": "#6F6E69"
-      }
-    },
-    {
-      "scope": [
-        "support.function.go"
-      ],
+      "name": "storageModifiers",
+      "scope": ["storage.modifier", "keyword.modifier", "storage.type"],
       "settings": {
         "foreground": "#205EA6"
       }
     },
     {
-      "scope": [
-        "keyword.operator.address.go",
-        "keyword.operator.pointer.go"
-      ],
+      "name": "comments",
+      "scope": ["comment", "punctuation.definition.comment"],
       "settings": {
-        "foreground": "#AD8301"
+        "foreground": "#6F6E69"
       }
     },
     {
-      "scope": [
-        "keyword.channel.go"
-      ],
+      "name": "docComments",
+      "scope": ["comment.documentation", "comment.line.documentation"],
+      "settings": {
+        "foreground": "#B7B5AC"
+      }
+    },
+    {
+      "name": "numbers",
+      "scope": ["constant.numeric"],
       "settings": {
         "foreground": "#5E409D"
       }
     },
     {
-      "scope": [
-        "storage.type.numeric.go",
-        "storage.type.string.go",
-        "storage.type.error.go",
-        "storage.type.boolean.go",
-        "storage.type.byte.go",
-        "storage.type.uintptr.go",
-        "storage.type.error.go",
-        "storage.type.rune.go",
-        "storage.type.complex.go"
-      ],
+      "name": "booleans",
+      "scope": ["constant.language.boolean", "constant.language.json"],
       "settings": {
         "foreground": "#AD8301"
       }
     },
     {
-      "scope": [
-        "entity.name.tag.astro"
-      ],
+      "name": "operators",
+      "scope": ["keyword.operator"],
+      "settings": {
+        "foreground": "#AF3029"
+      }
+    },
+    {
+      "name": "macros",
+      "scope": ["entity.name.function.preprocessor", "meta.preprocessor"],
       "settings": {
         "foreground": "#205EA6"
       }
     },
     {
-      "scope": [
-        "support.class.component.astro"
-      ],
+      "name": "preprocessor",
+      "scope": ["meta.preprocessor"],
       "settings": {
-        "foreground": "#A02F6F",
-        "fontStyle": ""
+        "foreground": "#A02F6F"
       }
     },
     {
-      "scope": [
-        "support.function.builtin.python",
-        "meta.function-call.generic.python"
-      ],
+      "name": "urls",
+      "scope": ["markup.underline.link"],
       "settings": {
-        "foreground": "#BC5215"
+        "foreground": "#205EA6"
       }
     },
     {
+      "name": "tags",
+      "scope": ["entity.name.tag"],
+      "settings": {
+        "foreground": "#205EA6"
+      }
+    },
+    {
+      "name": "jsxTags",
+      "scope": ["support.class.component"],
+      "settings": {
+        "foreground": "#A02F6F"
+      }
+    },
+    {
+      "name": "attributes",
+      "scope": ["entity.other.attribute-name", "meta.attribute"],
+      "settings": {
+        "foreground": "#AD8301"
+      }
+    },
+    {
+      "name": "types",
+      "scope": ["support.type"],
+      "settings": {
+        "foreground": "#AD8301"
+      }
+    },
+    {
+      "name": "constants",
+      "scope": ["variable.other.constant", "variable.readonly"],
+      "settings": {
+        "foreground": "#100F0F"
+      }
+    },
+    {
+      "name": "labels",
+      "scope": ["entity.name.label", "punctuation.definition.label"],
+      "settings": {
+        "foreground": "#A02F6F"
+      }
+    },
+    {
+      "name": "namespaces",
       "scope": [
-        "entity.name.function.decorator.python"
+        "entity.name.namespace",
+        "storage.modifier.namespace",
+        "markup.bold.markdown"
       ],
       "settings": {
         "foreground": "#AD8301"
       }
     },
     {
+      "name": "modules",
+      "scope": ["entity.name.module", "storage.modifier.module"],
+      "settings": {
+        "foreground": "#AF3029"
+      }
+    },
+    {
+      "name": "typeParameters",
+      "scope": ["variable.type.parameter", "variable.parameter.type"],
+      "settings": {
+        "foreground": "#BC5215"
+      }
+    },
+    {
+      "name": "exceptions",
+      "scope": ["keyword.control.exception", "keyword.control.trycatch"],
+      "settings": {
+        "foreground": "#A02F6F"
+      }
+    },
+    {
+      "name": "decorators",
       "scope": [
-        "entity.name.function.rust"
+        "meta.decorator",
+        "punctuation.decorator",
+        "entity.name.function.decorator"
       ],
+      "settings": {
+        "foreground": "#AD8301"
+      }
+    },
+    {
+      "name": "calls",
+      "scope": ["variable.function"],
+      "settings": {
+        "foreground": "#100F0F"
+      }
+    },
+    {
+      "name": "punctuation",
+      "scope": [
+        "punctuation",
+        "punctuation.terminator",
+        "punctuation.definition.tag",
+        "punctuation.separator",
+        "punctuation.definition.string",
+        "punctuation.section.block"
+      ],
+      "settings": {
+        "foreground": "#6F6E69"
+      }
+    },
+    {
+      "name": "yellow",
+      "scope": [
+        "storage.type.numeric.go",
+        "storage.type.byte.go",
+        "storage.type.boolean.go",
+        "storage.type.string.go",
+        "storage.type.uintptr.go",
+        "storage.type.error.go",
+        "storage.type.rune.go",
+        "constant.language.go",
+        "support.class.dart",
+        "keyword.other.documentation",
+        "storage.modifier.import.java",
+        "punctuation.definition.list.begin.markdown",
+        "punctuation.definition.quote.begin.markdown",
+        "meta.separator.markdown",
+        "entity.name.section.markdown"
+      ],
+      "settings": {
+        "foreground": "#AD8301"
+      }
+    },
+    {
+      "name": "green",
+      "scope": [],
+      "settings": {
+        "foreground": "#66800B"
+      }
+    },
+    {
+      "name": "cyan",
+      "scope": [
+        "markup.italic.markdown",
+        "support.type.python",
+        "variable.legacy.builtin.python",
+        "support.constant.property-value.css",
+        "storage.modifier.attribute.swift"
+      ],
+      "settings": {
+        "foreground": "#24837B"
+      }
+    },
+    {
+      "name": "blue",
+      "scope": [],
+      "settings": {
+        "foreground": "#205EA6"
+      }
+    },
+    {
+      "name": "purple",
+      "scope": ["keyword.channel.go", "keyword.other.platform.os.swift"],
+      "settings": {
+        "foreground": "#5E409D"
+      }
+    },
+    {
+      "name": "magenta",
+      "scope": ["punctuation.definition.heading.markdown"],
+      "settings": {
+        "foreground": "#A02F6F"
+      }
+    },
+    {
+      "name": "red",
+      "scope": [],
+      "settings": {
+        "foreground": "#AF3029"
+      }
+    },
+    {
+      "name": "orange",
+      "scope": [],
       "settings": {
         "foreground": "#BC5215"
       }


### PR DESCRIPTION
### Changes

I've reduced the number of lines from 1145 to 548 for each vscode Flexoki variant. I reduced the specificity to increase the support for every language.

Both variants were generated by [Tinte](https://github.com/Railly/tinte), where I have abstracted 13 providers at the moment, I'm planning to expose it via npm package & CLI in the near future. This will enable creating variants easily with the same palette.

### Generators
![image](https://github.com/kepano/flexoki/assets/51397083/bd92e40e-012f-481e-a210-e33738d555b5)

### Flexoki Dark
![image](https://github.com/kepano/flexoki/assets/51397083/5ca53dda-96ea-461c-8a55-49d7d5d05762)

### Flexoki Light
![image](https://github.com/kepano/flexoki/assets/51397083/96d7a37c-ebe8-4f77-b172-d08ea78b3177)

Closes #39
Closes #36 
