### PR TITLE
add Helix editor theme to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Flexoki is available for the following apps and tools.
 - [Alacritty](https://github.com/kepano/flexoki/tree/main/alacritty) by @willtheodore
 - [Emacs](https://github.com/crmsnbleyd/flexoki-emacs-theme) by @crmsnbleyd
 - [fish](https://github.com/kepano/flexoki/tree/main/fish) by @Orest58008
+- [Helix](https://github.com/ftqo/flexoki-helix-theme) by @ftqo
 - [IntelliJ](https://github.com/kepano/flexoki/tree/main/intellij) by @annoyingmouse
 - [iTerm2](https://github.com/kepano/flexoki/tree/main/iterm2) by @techvlad and @pingiun
 - [Kitty](https://github.com/kepano/flexoki/tree/main/kitty) by @peterjbachman


### PR DESCRIPTION
Hi, I've just ported the theme to Helix! I will maintain this, but I'm unsure if it's final yet. I've tried to keep colors similar to the VSCode version provided by One Hunter.