### PR TITLE
kitty flexoki_dark.conf foreground color fix

### DIFF
--- a/kitty/flexoki_dark.conf
+++ b/kitty/flexoki_dark.conf
@@ -7,13 +7,13 @@
 ## blurb: An inky color scheme for prose and code
 
 # The basic colors
-foreground              #FFFCF0
+foreground              #CECDC3
 background              #100F0F
-selection_foreground    #FFFCF0
+selection_foreground    #CECDC3
 selection_background    #403E3C
 
 # Cursor colors
-cursor                  #FFFCF0
+cursor                  #CECDC3
 cursor_text_color       #100F0F
 
 # kitty window border colors
@@ -21,7 +21,7 @@ active_border_color     #AF3029
 inactive_border_color   #403E3C
 
 # Tab bar colors
-active_tab_foreground   #FFFCF0
+active_tab_foreground   #CECDC3
 active_tab_background   #403E3C
 inactive_tab_foreground #878580
 inactive_tab_background #282726
@@ -56,5 +56,5 @@ color6  #24837B
 color14 #3AA99F
 
 # white
-color7  #F2F0E5
-color15 #FFFCF0
+color7  #878580
+color15 #CECDC3


### PR DESCRIPTION
use dark theme `txt` color instead of light theme `bg` for the `foreground` and the `white`.