### PR TITLE
draft: Add foot port of flexoki

### DIFF
--- a/foot/flexoki-dark
+++ b/foot/flexoki-dark
@@ -1,0 +1,26 @@
+# -*- conf -*-
+# Flexoki Dark
+
+[cursor]
+color=100F0F CECDC3
+
+[colors]
+background=100F0F 
+foreground=CECDC3 
+regular0=282726  # black
+regular1=AF3029  # red
+regular2=66800B  # green
+regular3=AD8301  # yellow
+regular4=205EA6  # blue
+regular5=A02F6F  # magenta
+regular6=24837B  # cyan
+regular7=CECDC3  # white
+
+bright0=878580 # bright black
+bright1=D14D41 # bright red
+bright2=879A39 # bright green
+bright3=D0A215 # bright yellow
+bright4=4385BE # bright blue
+bright5=CE5D97 # bright magenta
+bright6=3AA99F # bright cyan
+bright7=CECDC3 # bright white


### PR DESCRIPTION
This is an attempt at porting the flexoki colour scheme to the [foot](https://codeberg.org/dnkl/foot) terminal. 
I'm marking this as draft because I only ported the dark variant so far and I also wanted to ask if the colours were used properly, after seeing different ports to different terminals seemingly using the colours in different ways. I've included a screenshot of the alacritty port from the repo (the repo doesn't have screenshots of it) which is why I questioned the way I used the colours. Other ports to terminal emulators have screenshots already, and use the colours differently as well.
I've tried sticking to the recommended mappings from [the website](https://stephango.com/flexoki) and not stray away from them.

This foot port:
![foot](https://github.com/user-attachments/assets/1dcaae97-8874-40af-9869-4762df2ad656)

The alacritty port currently in the repo:
![alacritty](https://github.com/user-attachments/assets/818d6c34-32f1-43a4-8247-b242e863a100)

I personally like the darker background used in my port (colour $black) and in other terminal ports, but I'd rather ask whether you'd prefer the colour palette being used differently. 
Depending on how strict you are with all ports looking uniform, possibly deciding on a single terminal colour palette and reviewing all the terminal ports accordingly might be desirable.
Waiting for feedback. 
Thanks for your time and work, take care.