### PR TITLE
Python/Matplotlib Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Flexoki is available for the following apps and tools.
 - [Wikipedia UserCSS](https://userstyles.world/style/17944/wikipedia-flexoki) (requires [Stylus](https://github.com/openstyles/stylus/#releases)) by @KraXen72
 - [Figma](https://www.figma.com/community/file/1293274371462921490/flexoki) by @kepano
 - [GIMP palette](https://github.com/kepano/flexoki/tree/main/gimp) by @xTibor
+- [Python/Matplotlib](https://github.com/kepano/flexoki/tree/main/python-matplotlib) by @moss-xyz
 
 ## Contributing
 

--- a/python-matplotlib/README.md
+++ b/python-matplotlib/README.md
@@ -1,0 +1,12 @@
+*flexoki-py* is a Python library that provides easy access to [Flexoki](https://github.com/kepano/flexoki), an "inky color scheme for prose and code".
+
+The intent behind this package is to make the colors from Flexoki accessible to other Python packages centered around graphics, especially [matplotlib](https://github.com/matplotlib/matplotlib).
+
+Key features:
+
+- Access to full library of Flexoki 2.0 colors
+- Shortcuts to collections of colors (referred to as "Palettes")
+- Robust filtering of colors based on hue and lightness
+- Ability to register colors and palettes with matplotlib (as named colors and colormaps, respectively)
+
+For guides related to installation and usage, please refer to the GitHub repository: [flexoki-py](https://github.com/moss-xyz/flexoki-py)


### PR DESCRIPTION
I wrote a package to exposure Flexoki's color scheme to Python, with a specific focus on integrating with `matplotlib`, which is popular for graphing.

Mainly did it as practice for writing packages, but thought it might be useful for others as well, so sharing here - the package itself is available on [GitHub](https://github.com/moss-xyz/flexoki-py) and can be installed via PyPi.

Let me know if this is sufficient to merge in!