### PR TITLE
Fix Discord link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Flexoki is available for the following apps and tools.
 
 - [Alacritty](https://github.com/kepano/flexoki/tree/main/alacritty) by @willtheodore
 - [Chrome](https://github.com/kepano/flexoki/tree/main/chrome) by @FormalSnake
-- [Discord](https://github.com/kepano/flexoki/discord) by @thatoddshade using [Discord Recolor](https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/DiscordRecolor)
+- [Discord](https://github.com/kepano/flexoki/tree/main/discord) by @thatoddshade using [Discord Recolor](https://github.com/mwittrien/BetterDiscordAddons/tree/master/Themes/DiscordRecolor)
 - [Emacs](https://github.com/crmsnbleyd/flexoki-emacs-theme) by @crmsnbleyd
 - [Firefox](https://github.com/ddogfoodd/firefox-flexoki-dynamic-theme) by @ddogfoodd
 - [fish](https://github.com/kepano/flexoki/tree/main/fish) by @Orest58008


### PR DESCRIPTION
The link to the Discord theme was incorrect. Should point to the correct place now!