### PR TITLE
Fix incorrect fish light theme name

### DIFF
--- a/fish/flexoki-light.theme
+++ b/fish/flexoki-light.theme
@@ -1,4 +1,4 @@
-# name: Flexoki Dark
+# name: Flexoki Light
 # url: https://stephango.com/flexoki
 # preferred_background: fffcf0 # bg
 


### PR DESCRIPTION
Fish light theme was incorrectly named 'Flexoki Dark'