### PR TITLE
Fix incorrect information in i3/README.md

### DIFF
--- a/i3/README.md
+++ b/i3/README.md
@@ -1,7 +1,7 @@
 # Usage
 
-1. Copy selected mode or flexoki-full for raw range to `~/.config/waybar/`
-2. Include the file at the top of your `style.css`:
+1. Copy selected mode or flexoki-full for raw range to `~/.config/i3/` (or `~/.config/sway/` if you're using Sway)
+2. Include the file at the top of your config file:
 ```
 include flexoki-<mode>
 ```


### PR DESCRIPTION
The README file for i3 was referencing files for waybar. Also added a note about Sway, as it's compatible with i3.