### PR TITLE
chore: update zed's extension id

### DIFF
--- a/zed/extension.toml
+++ b/zed/extension.toml
@@ -1,4 +1,4 @@
-id = "flexoki"
+id = "flexoki-themes"
 name = "Flexoki"
 version = "2.0.0"
 schema_version = 1


### PR DESCRIPTION
As part of an ongoing effort to introduce Flexoki's update theme as a Zed extension, this commit updates the id of the extension from `flexoki` to `flexoki-themes` so as to migrate existing users of the old theme to this updated version.

For more context on this change, refer to this Pull Request - https://github.com/zed-industries/extensions/pull/2408 .