### PR TITLE
[ZED] Fix terminal white text colors for Flexoki Light

### DIFF
--- a/zed/themes/flexoki.json
+++ b/zed/themes/flexoki.json
@@ -424,8 +424,8 @@
         "terminal.ansi.cyan": "#24837B",
         "terminal.ansi.bright_cyan": "#3AA99F",
         "terminal.ansi.dim_cyan": "#164F4A",
-        "terminal.ansi.white": "#FFFCF0",
-        "terminal.ansi.bright_white": "#FFFCF0",
+        "terminal.ansi.white": "#6F6E69",
+        "terminal.ansi.bright_white": "#B7B5AC",
         "terminal.ansi.dim_white": "#F2F0E5",
         "link_text.hover": "#205EA6",
         // For each of the colors in this section, we'll use the color from the


### PR DESCRIPTION
It is important that the colors set for `terminal.ansi.white` and `terminal.ansi.bright_white` contrast on `terminal.background`.

Under the current settings, some text is totally invisible in my terminal!

<img width="507" height="233" alt="before" src="https://github.com/user-attachments/assets/31795728-e55b-4363-8d28-552b74c65051" />

This PR sets `bright_white` to tx-3 and `white` to tx-2 to resolve this issue. 


<img width="439" height="180" alt="after" src="https://github.com/user-attachments/assets/276e4b65-96b6-4794-9f32-df28ed143be7" />

May be worth checking IDE implementations for this color contrast edge case.
