### PR TITLE
[ZED] Promote version number in extension.toml

### DIFF
--- a/zed/extension.toml
+++ b/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "flexoki-themes"
 name = "Flexoki"
-version = "2.0.0"
+version = "2.0.1"
 schema_version = 1
 authors = [
     "Steph Ango <stephango.com>",


### PR DESCRIPTION
Didn't know this when I submitted #122, but it seems there are [a few steps](https://zed.dev/docs/extensions/developing-extensions#updating-an-extension) that must be done before changes will be reflected on the Zed extension store.

> To update an extension, open a PR to [the zed-industries/extensions repo](https://github.com/zed-industries/extensions).
> In your PR do the following:
> 1. Update the extension's submodule to the commit of the new version.
> 2. Update the version field for the extension in extensions.toml
>     - Make sure the version matches the one set in extension.toml at the particular commit.

Which is a bit annoying, but I guess there's a [Github Action ](https://github.com/huacnlee/zed-extension-action) you can setup to automate the process. Probably overkill for Flexoki.

After this PR is merged, I can open up a PR on the Zed extensions repository to handle the rest.

Thanks for the beautiful theme, and all the work you do on Obsidian!
