### PR TITLE
chore: bump Zed extension version to 2.0.2

### DIFF
--- a/zed/extension.toml
+++ b/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "flexoki-themes"
 name = "Flexoki"
-version = "2.0.1"
+version = "2.0.2"
 schema_version = 1
 authors = [
     "Steph Ango <stephango.com>",


### PR DESCRIPTION
I plan to submit a PR to release this after this is merged.