### PR TITLE
feat: add flexoki for zensical

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Flexoki is available for the following apps and tools.
 - [pywal](https://github.com/kepano/flexoki/tree/main/pywal) by @hydroakri
 - [Starlight](https://delucis.github.io/starlight-theme-flexoki/) by @delucis
 - [VitePress](https://github.com/mancuoj/vitepress-theme-flexoki) by @mancuoj
+- [Zensical](https://github.com/leightonpayne/flexoki-zensical) by @leightonpayne
 
 ### Other
 


### PR DESCRIPTION
Adds a link to a packaged Flexoki theme extension for [Zensical](https://zensical.org/). Hosted in a separate repo that is published to PyPI to make it `pip`/`uv` installable, as per the [theme packaging recommendations](https://zensical.org/docs/customization/?h=theme#packaging-themes) from the Zensical developers. I am using it already for several projects: https://flexoki.leightonpayne.dev/showcase/.