### PR TITLE
feat(wezterm): add tab bar colors for dark and light themes

### DIFF
--- a/wezterm/Flexoki Dark.toml
+++ b/wezterm/Flexoki Dark.toml
@@ -34,6 +34,29 @@ cursor_fg = "#100F0F"
 selection_bg = "#282726"
 selection_fg = "#CECDC3"
 
+[colors.tab_bar]
+background = "#100F0F"
+
+[colors.tab_bar.active_tab]
+bg_color = "#4385BE"
+fg_color = "#FFFCF0"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#282726"
+fg_color = "#575653"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#343331"
+fg_color = "#CECDC3"
+
+[colors.tab_bar.new_tab]
+bg_color = "#282726"
+fg_color = "#575653"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#343331"
+fg_color = "#CECDC3"
+
 [colors.indexed]
 
 [metadata]

--- a/wezterm/Flexoki Light.toml
+++ b/wezterm/Flexoki Light.toml
@@ -37,6 +37,29 @@ cursor_fg = "#FFFCF0"
 selection_fg = "#100F0F"
 selection_bg = "#E6E4D9"
 
+[colors.tab_bar]
+background = "#FFFCF0"
+
+[colors.tab_bar.active_tab]
+bg_color = "#4385BE"
+fg_color = "#FFFCF0"
+
+[colors.tab_bar.inactive_tab]
+bg_color = "#E6E4D9"
+fg_color = "#B7B5AC"
+
+[colors.tab_bar.inactive_tab_hover]
+bg_color = "#DAD8CE"
+fg_color = "#100F0F"
+
+[colors.tab_bar.new_tab]
+bg_color = "#E6E4D9"
+fg_color = "#B7B5AC"
+
+[colors.tab_bar.new_tab_hover]
+bg_color = "#DAD8CE"
+fg_color = "#100F0F"
+
 [colors.indexed]
 
 [metadata]


### PR DESCRIPTION
Add `[colors.tab_bar]` sections to the Flexoki Dark and Flexoki Light WezTerm color schemes.

WezTerm supports tab bar color customization via dedicated keys, but the current theme files do not include them, leaving the tab bar with WezTerm's default colors regardless of the active scheme.

**Changes:**
- `active_tab`: Flexoki blue (`#4385BE`) background with paper white foreground
- `inactive_tab` / `new_tab`: Flexoki base-950 background with muted foreground
- `inactive_tab_hover` / `new_tab_hover`: slightly lighter base-900 hover state
- `background`: matches the terminal background of each variant

Colors are drawn from the existing Flexoki palette already present in each file.