### PR TITLE
Add Flexoki port for Voltius (SSH terminal client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Flexoki is available for the following apps and tools.
 - [Ulysses](https://github.com/kepano/flexoki/tree/main/ulysses) by @jasonekratz
 - [Visual Studio Code](https://github.com/kepano/flexoki/tree/main/vscode) by @Railly
 - [Vim](https://github.com/kepano/flexoki/tree/main/vim) by @stevepan643
+- [Voltius](https://github.com/kepano/flexoki) by @ezhkov-ph
 - [Warp](https://github.com/kepano/flexoki/tree/main/warp-terminal) by @tplesnar
 - [Waybar](https://github.com/kepano/flexoki/tree/main/waybar) by @Orest58008
 - [WezTerm](https://github.com/kepano/flexoki/tree/main/wezterm) by @jbromley


### PR DESCRIPTION
Adds Voltius (SSH terminal client) to the list of Flexoki ports.

- Light and dark theme files: https://github.com/ezhkov-ph/flexoki-voltius
- Attribution to Flexoki / Steph Ango included in the port's README per license requirements.